### PR TITLE
Refine architecture init prompts and CLI preset

### DIFF
--- a/orchestration/init.md
+++ b/orchestration/init.md
@@ -488,6 +488,9 @@ When the user selects a built-in framework preset:
 1. Resolve its preset file from `{adapter_path:presets}`.
 2. Locate `## Init Interview` and read that section through the next level-two heading. Do not load unrelated review guidance solely to run the interview when the host can read a section selectively.
 3. Merge the preset questions into the matching generic interview phases. Ask them sequentially and only when relevant to the selected application type or an earlier answer; do not ask a generic and preset question twice when they seek the same decision.
+   - Preset `### API Conventions & Tooling` questions belong to Phase 3.
+   - Preset `### Code Style & Tooling` questions belong to Phase 6.
+   - When a preset question overlaps a generic question, ask the preset wording only when it adds framework-specific detail; otherwise ask the generic question once and record the answer for both decisions.
 4. Record each answer as a framework-neutral architectural decision plus its selected framework implementation.
 5. If the preset has no `## Init Interview` section, continue with the generic phases below without inventing framework requirements.
 
@@ -542,12 +545,25 @@ How strict should module boundaries be enforced?
 
 ---
 
-# Phase 3 — Contracts & Validation
+Ask:
+
+```text
+Are there specific subfolder conventions for features/modules?
+(Only ask if the project has or plans more than a trivial single-module shape)
+
+Examples:
+- consistent subfolders (dto/, entities/, interfaces/, guards/, strategy/)
+```
+
+---
+
+# Phase 3 — Contracts & API Conventions
 
 Determine:
 
 * validation strategy
-* request/response contracts
+* request/response contracts (REST/API conventions)
+* API documentation standards
 * serialization standards
 * frontend/backend boundaries
 
@@ -571,9 +587,37 @@ What is the standard response structure?
 
 ---
 
+Ask:
+
+```text
+What are the generic REST/API contract conventions?
+
+Examples:
+- status code conventions per verb
+- pagination shape
+- error response shape / error codes
+- versioning strategy
+```
+
+---
+
+Ask:
+
+```text
+What is the API documentation strategy?
+
+Examples:
+- Is Swagger/OpenAPI (or equivalent) required?
+- Does its presence gate merge/review?
+```
+
+---
+
 ## Preset Contract Questions
 
 If the selected preset's `## Init Interview` includes contract or validation questions, ask them during this phase unless an earlier answer already resolves them. Do not ask the same question twice.
+
+Preset API-convention questions are also part of this phase. Ask them only when the selected application exposes the relevant kind of API, using the deduplication rule above.
 
 ---
 
@@ -663,6 +707,96 @@ Examples:
 
 ---
 
+Ask:
+
+```text
+Does a developer/operational guide already exist, or will one be maintained?
+
+Examples:
+- setup steps, DB migration/seed commands
+- CI/release process
+- third-party integration configs (OIDC providers, CORS setup)
+
+(If yes, record its path as a "Useful file refs" entry in the generated constitution instead of absorbing that operational content into the constitution itself.)
+```
+
+---
+
+Ask:
+
+```text
+If the active adapter supports per-artifact rules (e.g., `{adapter_path:artifact-rules-mechanism}`), do you want lightweight checklists for specs and design?
+(Skip if the active adapter lacks a per-artifact rule mechanism)
+```
+
+---
+
+# Phase 6 — Code Style & Tooling
+
+Determine:
+
+* linting/formatting strictness and progressive rollout policy
+* naming conventions across identifier kinds
+* forbidden/required patterns and enforcement subset
+* logging standards (structured vs console, levels, retention if applicable)
+
+If the selected preset's `## Init Interview` includes a `### Code Style & Tooling` section, merge those questions here. Ask framework-specific questions only when the project uses the corresponding tool or pattern; do not turn examples into mandatory rules.
+
+---
+
+## Questions
+
+Ask:
+
+```text
+How strict should code styling and tooling be enforced?
+
+Examples:
+- lint/format as advisory or blocking
+- is there a progressive-strictness policy (e.g., rules start at warn and promote to error once stable)? (Capture as explicit rollout policy)
+```
+
+---
+
+Ask:
+
+```text
+What are the naming conventions per identifier kind?
+
+(Ask for a short table covering variables, booleans, types/classes/interfaces, enum members, constants, object literal keys - don't invent one)
+```
+
+---
+
+Ask:
+
+```text
+Are there any general forbidden/required patterns?
+
+Examples:
+- no console.log in committed code
+- no implicit any, explicit return types
+- strict equality, no wrapper-object constructors
+- secure randomness instead of Math.random() for security-sensitive values
+
+(Ask what subset of these the project actually wants enforced rather than dumping a fixed checklist)
+```
+
+---
+
+Ask:
+
+```text
+What is the logging standard?
+
+Examples:
+- structured logger vs console.log
+- log levels
+- rotation/retention rules (only ask retention specifics if the project already has or plans a logging module)
+```
+
+---
+
 # Rule Classification Logic
 
 Before generating rules, classify them.
@@ -679,6 +813,7 @@ Examples:
 * review expectations
 * engineering philosophy (Ponytail principles, YAGNI, minimal abstractions)
 * operational governance
+* naming conventions, linting strictness, and code style rules
 
 ---
 
@@ -693,9 +828,10 @@ Examples:
 * authorization strategy and its framework implementation, when selected
 * validation placement
 * async boundaries
-* response contracts
+* response contracts and REST/API conventions
 * module ownership rules
-* framework-specific architecture patterns
+* module and feature subfolder shapes
+* framework-specific architecture and decorator patterns
 * DRY and single-source-of-truth rules for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration
 * temporary/scratch files MUST use `-temp` or `-test` suffixes for easier cleanup
 
@@ -775,6 +911,8 @@ If the `flash-mem` MCP server is available, you MUST run the `update_project_sum
 6. Review Process
 7. High-Level Architecture Intent
 8. Governance and Evolution Policy
+9. Useful File References (optional)
+10. Per-Artifact Rules (e.g., OpenSpec rules block)
 ```
 
 ---
@@ -789,10 +927,13 @@ If the `flash-mem` MCP server is available, you MUST run the `update_project_sum
 5. Data Access Rules
 6. Async & Integration Rules
 7. Module Boundaries
-8. Framework-Specific Architecture Rules
-9. Blocking Architecture Violations (P0)
-10. Architecture Evolution Policy
-11. Refactor & Drift Handling
+8. Code Style & Tooling Rules
+9. Framework-Specific Architecture Rules
+10. Blocking Architecture Violations (P0)
+11. Architecture Evolution Policy
+12. Refactor & Drift Handling
+13. Useful File References (optional)
+14. Per-Artifact Rules (e.g., OpenSpec rules block)
 ```
 
 ---

--- a/presets/codeigniter.md
+++ b/presets/codeigniter.md
@@ -40,3 +40,18 @@ What application style are you using?
 - REST API
 - Hybrid
 ```
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```

--- a/presets/django.md
+++ b/presets/django.md
@@ -70,6 +70,22 @@ Ask:
 Which work must use Celery, Django Q, RQ, scheduled jobs, or another worker instead of blocking a request?
 ```
 
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/expressjs.md
+++ b/presets/expressjs.md
@@ -68,6 +68,22 @@ Ask:
 Which work requires queues, workers, schedulers, or event processing outside the HTTP request?
 ```
 
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/laravel.md
+++ b/presets/laravel.md
@@ -181,6 +181,22 @@ If the user selects Standard/General naming conventions during initialization, a
 - **Utility / Lib Files**: `kebab-case.ts` or `camelCase.ts`
 - **Props and State**: `camelCase`
 
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/nestjs.md
+++ b/presets/nestjs.md
@@ -81,6 +81,22 @@ Ask:
 Which workflows should use queues, events, schedulers, or NestJS microservice transports?
 ```
 
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/nextjs.md
+++ b/presets/nextjs.md
@@ -83,6 +83,19 @@ Ask:
 Which operations require a queue, workflow service, scheduled job, or external worker instead of a request-bound Server Action or Route Handler?
 ```
 
+
+### Code Style & Tooling
+
+Ask:
+
+```text
+Which framework-specific lint/style conventions apply to this project, if any?
+
+Examples:
+- ESLint strictness, Prettier formatting
+- Forbidden hooks patterns
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/nodejs-cli.md
+++ b/presets/nodejs-cli.md
@@ -1,0 +1,180 @@
+---
+description: Apply Node.js CLI-specific architecture conventions during initialization and architecture review.
+---
+
+# Architecture Guard — Node.js CLI Architecture Adapter
+
+## Init Interview
+
+Ask these questions sequentially after the Node.js CLI preset is selected. Skip questions already resolved by existing constitution context.
+
+### Application Architecture
+
+Ask:
+
+```text
+How should the CLI application be organized?
+
+- Commands → Core Services
+- Commands → Controllers → Services
+- Feature-oriented modules
+- Minimal command handlers for simple tools
+- Hybrid based on complexity
+```
+
+### Dependency Wiring
+
+Ask:
+
+```text
+How should dependencies be wired?
+
+- Direct imports for stateless infrastructure
+- Explicit factory functions
+- Request/Context objects passed down
+- A project-adopted DI container
+```
+
+### Persistence and File System
+
+Ask:
+
+```text
+Which strategy is used for data boundaries like File System or External APIs, and where are they coordinated?
+```
+
+## Senior Engineering Lens
+
+Apply the framework mapping with senior judgment:
+
+- Treat directory names, file length, and pattern names as signals, not proof.
+- Start from the Constitution and patterns already working in the repository. Do not introduce layers solely because this preset lists them.
+- Distinguish correctness requirements from maintainability advice.
+- For each finding, teach the reasoning.
+- Evaluate tradeoffs that matter for CLI tools, such as startup time, terminal output verbosity, error codes, and graceful exits.
+- Use the core architecture review rules first. This adapter refines generic architecture concepts with **Node.js CLI** conventions, emphasizing command entry points, terminal I/O boundaries, and file-system/data access.
+
+---
+
+## Boundary Mapping
+
+When reviewing a Node.js CLI project, map generic architecture boundaries to CLI primitives:
+
+### Entry Boundary
+
+| Generic Concept | Node.js CLI Equivalent |
+| --- | --- |
+| Entry point for execution | Command Parsers (Commander, Yargs, Oclif, `process.argv`) |
+| Request processing | Command Handlers (`action()` or `handler()`) |
+| Terminal Output/Input | `console.log`, `console.error`, `chalk`, `ora`, `inquirer`, `stdin`/`stdout` |
+
+### Application/Domain Boundary
+
+| Generic Concept | Node.js CLI Equivalent |
+| --- | --- |
+| Shared logic coordination | Core Services (`src/services/` or `src/core/`) |
+| Business rules and decisions | Pure functions independent of terminal or parsing |
+
+### Data Boundary
+
+| Generic Concept | Node.js CLI Equivalent |
+| --- | --- |
+| Data persistence | File System access (`fs`, `path`), databases |
+| External communication | External APIs, sub-process execution (`child_process`) |
+
+---
+
+## Detection Rules
+
+### Fat Command Handlers
+
+- **Description:** Command handlers must only orchestrate arguments parsing and call core services. They should not contain complex business logic, long procedural steps, or deep conditional logic.
+- **Why:** Fat command handlers make testing business logic impossible without mocking `process.argv` and stdout, leading to fragile tests and spaghetti code.
+- **Rule:** If a command handler exceeds coordinating inputs and calling a service (e.g., performing actual file manipulation loops or API data mapping), flag it as a violation. Respect an existing repository convention when the handler is deliberately the application boundary.
+
+### Scattered Process Exit
+
+- **Description:** Calls to `process.exit()` must be constrained to the outermost entry boundary (e.g. `bin/cli.js` or top-level command catch blocks).
+- **Why:** Deeply nested `process.exit()` calls make the CLI untestable and prevent the application from cleanly cleaning up resources or being used programmatically.
+- **Rule:** Flag direct `process.exit()` calls found inside Core Services, Domain logic, or Data layers. Prefer throwing typed errors and handling them at one top-level boundary; `process.exitCode` may be set by that boundary when cleanup must still run. Allow a documented adapter-specific exception only when the project already centralizes exits through that adapter.
+
+### Hardcoded UI in Core
+
+- **Description:** Terminal UI libraries (`chalk`, `ora`, `inquirer`, `console.log`) should not be used deep within Application or Domain services.
+- **Why:** Coupling core logic to terminal output prevents the logic from being reused across different commands, in tests, or in a web/GUI context.
+- **Rule:** Flag UI rendering library imports or terminal writes (`console.log`, `console.error`, and equivalent stdout/stderr writes) inside Core Services. Services should return data or emit events, and the Entry boundary should handle presentation. A dedicated output/presentation adapter is an explicit boundary and is not a violation merely because it uses a terminal library.
+
+---
+
+## Examples
+
+### Spaghetti Command vs Clean Command
+
+**Violation (Spaghetti Command):**
+```javascript
+// src/commands/build.js
+const fs = require('fs');
+const chalk = require('chalk');
+
+program.command('build <dir>')
+  .action((dir) => {
+    console.log(chalk.blue(`Building ${dir}...`));
+
+    // Core logic mixed with entry boundary and UI
+    if (!fs.existsSync(dir)) {
+      console.log(chalk.red('Directory not found!'));
+      throw new Error('Directory not found!'); // Handle once at the top-level boundary
+    }
+
+    const files = fs.readdirSync(dir);
+    for (const file of files) {
+      if (file.endsWith('.js')) {
+        // Business logic...
+      }
+    }
+
+    console.log(chalk.green('Done!'));
+  });
+```
+
+**Clean (Proper Boundaries):**
+```javascript
+// src/commands/build.js
+const chalk = require('chalk');
+const buildService = require('../core/buildService');
+
+program.command('build <dir>')
+  .action(async (dir) => {
+    try {
+      const result = await buildService.buildDirectory(dir);
+      console.log(chalk.green(`Done! Built ${result.filesProcessed} files.`));
+    } catch (error) {
+      console.error(chalk.red(error.message));
+      process.exitCode = 1;
+    }
+  });
+
+// src/core/buildService.js
+const fs = require('fs');
+
+async function buildDirectory(dir) {
+  if (!fs.existsSync(dir)) {
+    throw new Error('Directory not found!'); // Throws instead of process.exit
+  }
+  // Pure business logic...
+  return { filesProcessed: 10 }; // Returns data instead of console.log
+}
+
+module.exports = { buildDirectory };
+```
+
+---
+
+## Output Format
+
+When generating an architecture review for a CLI application, structure the output as follows:
+
+1. **Summary:** Brief overview of architecture health, focusing on separation of CLI parsing from core logic.
+2. **Boundary Violations:** List of infractions related to Entry, Application, or Data boundaries.
+3. **Anti-Patterns Detected:** Highlight occurrences of Fat Command Handlers, Scattered Process Exits, or Hardcoded UI in Core.
+4. **Actionable Recommendations:** Provide precise refactoring steps with code snippets for each violation.

--- a/presets/nuxtjs.md
+++ b/presets/nuxtjs.md
@@ -61,6 +61,19 @@ Ask:
 Where should database access, secrets, server integrations, caching, and background work live?
 ```
 
+
+### Code Style & Tooling
+
+Ask:
+
+```text
+Which framework-specific lint/style conventions apply to this project, if any?
+
+Examples:
+- ESLint strictness, Prettier formatting
+- Forbidden hooks patterns
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/react-native.md
+++ b/presets/react-native.md
@@ -89,6 +89,19 @@ Ask:
 How should secure storage, ordinary persistence, API clients, authentication refresh, push notifications, deep links, background work, analytics, and crash reporting be isolated?
 ```
 
+
+### Code Style & Tooling
+
+Ask:
+
+```text
+Which framework-specific lint/style conventions apply to this project, if any?
+
+Examples:
+- ESLint strictness, Prettier formatting
+- Forbidden hooks patterns
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/react.md
+++ b/presets/react.md
@@ -62,6 +62,19 @@ Ask:
 Which router owns navigation, and how should route visibility differ from server-enforced authorization?
 ```
 
+
+### Code Style & Tooling
+
+Ask:
+
+```text
+Which framework-specific lint/style conventions apply to this project, if any?
+
+Examples:
+- ESLint strictness, Prettier formatting
+- Forbidden hooks patterns
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/springboot.md
+++ b/presets/springboot.md
@@ -66,6 +66,22 @@ Ask:
 How should Spring Security authorization be expressed, and which work belongs in events, messaging, @Async, or scheduled jobs?
 ```
 
+
+### API Conventions & Tooling
+
+Ask:
+
+```text
+Which framework-specific API conventions or tooling rules apply to this project, if any?
+
+Ask only about conventions actually used by the project.
+
+Examples:
+- response or decorator patterns
+- status code mapping conventions
+- framework-specific linting strictness
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:

--- a/presets/vue.md
+++ b/presets/vue.md
@@ -69,6 +69,19 @@ Ask:
 How should API clients, caching, retries, authentication refresh, and error translation be centralized?
 ```
 
+
+### Code Style & Tooling
+
+Ask:
+
+```text
+Which framework-specific lint/style conventions apply to this project, if any?
+
+Examples:
+- ESLint strictness, Prettier formatting
+- Forbidden hooks patterns
+```
+
 ## Senior Engineering Lens
 
 Apply the framework mapping with senior judgment:


### PR DESCRIPTION
## Summary
- route preset API and code-style questions into the correct init phases
- deduplicate generic and framework-specific interview prompts
- refine framework tooling prompts to avoid imposing unused conventions
- add and harden the Node.js CLI architecture preset

## Validation
- git diff --check

## Notes
- The nested repository remote reports that the repository moved to `DyanGalih/architecture-guard`; the branch was pushed successfully through the configured remote.