### PR TITLE
feat: user story tracker sync and init scaffolding

### DIFF
--- a/cli/validate-sync-config.ts
+++ b/cli/validate-sync-config.ts
@@ -1,0 +1,43 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { parse } from 'yaml';
+import { z } from 'zod';
+
+const syncSchema = z.object({
+  provider: z.enum(['github', 'jira']),
+  repo: z.string().optional(), // For github
+  project: z.string().optional(), // For jira
+  enabled: z.boolean().default(true),
+});
+
+export type SyncConfig = z.infer<typeof syncSchema>;
+
+export function validateSyncConfig(configPath: string): SyncConfig {
+  const fullPath = path.resolve(configPath);
+  if (!fs.existsSync(fullPath)) {
+    throw new Error(`Sync config not found at ${fullPath}`);
+  }
+  
+  const content = fs.readFileSync(fullPath, 'utf8');
+  let parsed: unknown;
+  try {
+    parsed = parse(content);
+  } catch (e) {
+    throw new Error(`Invalid YAML format in ${configPath}: ${e}`);
+  }
+  
+  return syncSchema.parse(parsed);
+}
+
+// If run directly
+if (require.main === module) {
+  try {
+    const configPath = process.argv[2] || '.architecture-guard/sync.yml';
+    const config = validateSyncConfig(configPath);
+    console.log(JSON.stringify(config, null, 2));
+    process.exit(0);
+  } catch (e) {
+    console.error(e instanceof Error ? e.message : e);
+    process.exit(1);
+  }
+}

--- a/commands/governed-delivery-team.md
+++ b/commands/governed-delivery-team.md
@@ -85,7 +85,11 @@ Before engineering planning begins, generate a business-oriented User Story repr
 3. Ensure the User Story is understandable by technical and non-technical stakeholders.
 4. Persist the generated User Story as `<feature-name>.md` in the `<root>/user-stories/` directory with status `draft`.
 5. Present it for stakeholder review and stop before engineering planning until the user explicitly accepts it. Record the result as `approved` in the file.
-6. (Placeholder: Once approved, trigger the issue tracker MCP sync here, e.g., create GitHub Issue, if configured in governance).
+6. Once the User Story is approved, check for the presence of `.architecture-guard/sync.yml`. If it exists:
+   - Run `npx tsx src/cli/validate-sync-config.ts` to strictly validate the configuration.
+   - If the configuration is valid and `enabled: true`, read the User Story content and push it to the configured provider (e.g., via your `github-mcp-server` to create an issue).
+   - Record the resulting issue ID or URL in `.architecture-guard/sync_status.json` (e.g., `{ "status": "success", "issue_url": "..." }`).
+   - If the push fails, write `{ "status": "failed" }` to `.architecture-guard/sync_status.json` and output a non-blocking warning. Do NOT stop the delivery workflow.
 7. If a previously approved User Story has been modified after engineering artifacts were generated, mark it `review-required`, warn the user, and require re-approval before proceeding.
 
 ## Phase 5 — Spec & Proposal Gate

--- a/commands/init.md
+++ b/commands/init.md
@@ -429,6 +429,7 @@ If the user selects Team Development:
 1. Write `Mode: Team` into the governance rules (e.g., `openspec/config.yaml` or `.specify/memory/constitution.md`).
 2. Ask: "Which issue tracker MCP server should be used to sync User Stories? (e.g., github-mcp-server, jira, none)". Save this preference in the governance rules.
 3. Automatically scaffold a `user-stories/` directory at the project root to house global business requirements.
+4. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira). Then, automatically scaffold the `.architecture-guard/sync.yml` file configuring the chosen provider, the project/repo string, and `enabled: true`.
 
 ---
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,6 @@
 ## 2.3.0
+- Added: Enhanced `/ag-init` workflow to interactively scaffold `.architecture-guard/sync.yml` when a team issue tracker is selected.
+- Added: One-way sync feature for User Stories to external issue trackers (GitHub/Jira) via `.architecture-guard/sync.yml`.
 - Added framework-agnostic governed delivery and team User Story workflows.
 - Synchronized adapter contracts, prompt descriptions, installer registration, and project-relative command examples.
 - Added CLI update and JSON changed-file capabilities.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -130,3 +130,30 @@ Best for most features. It automatically chains Spec, Plan, and Task generation 
 7. **Verification:** Run `/ag-verify` as your final gate. **Ready to commit!**
 
 If you are specifically cleaning up duplicated logic (Brownfield), follow the [DRY Cleanup Guide](dry-cleanup.md) after your initialization pass. This keeps architecture concerns visible throughout the delivery lifecycle instead of concentrating them at the end.
+
+## User Story Tracker Sync (Team Delivery)
+
+The `ag-governed-delivery-team` workflow supports pushing approved User Stories to an external issue tracker (e.g., GitHub Issues or Jira) automatically. This is a one-way sync (push only) designed to minimize complexity while satisfying YAGNI.
+
+### Configuration
+
+Create a file at `.architecture-guard/sync.yml` in your workspace:
+
+```yaml
+# Supported providers: github, jira
+provider: github
+# Optional repository or project mapping
+repo: my-org/my-repo
+enabled: true
+```
+
+The configuration is strictly validated during the workflow using the `validate-sync-config.ts` CLI tool to ensure security constraints on untrusted input are met.
+
+### How it Works
+1. Run `/ag-governed-delivery-team`.
+2. A User Story is generated and proposed.
+3. Upon your explicit approval, the agent reads `sync.yml`.
+4. If enabled, the agent uses its MCP tools (e.g., `github-mcp-server`) to create the issue in your tracker.
+5. The result is recorded locally in `.architecture-guard/sync_status.json` (e.g., `{ "status": "success", "issue_url": "..." }`).
+
+If the push fails, the workflow gracefully degrades by logging a warning and writing `{ "status": "failed" }` to the status file without blocking local delivery.

--- a/orchestration/governed-delivery-team.md
+++ b/orchestration/governed-delivery-team.md
@@ -81,7 +81,11 @@ Before engineering planning begins, generate a business-oriented User Story repr
 3. Ensure the User Story is understandable by technical and non-technical stakeholders.
 4. Persist the generated User Story as `<feature-name>.md` in the `<root>/user-stories/` directory with status `draft`.
 5. Present it for stakeholder review and stop before engineering planning until the user explicitly accepts it. Record the result as `approved` in the file.
-6. (Placeholder: Once approved, trigger the issue tracker MCP sync here, e.g., create GitHub Issue, if configured in governance).
+6. Once the User Story is approved, check for the presence of `.architecture-guard/sync.yml`. If it exists:
+   - Run `npx tsx src/cli/validate-sync-config.ts` to strictly validate the configuration.
+   - If the configuration is valid and `enabled: true`, read the User Story content and push it to the configured provider (e.g., via your `github-mcp-server` to create an issue).
+   - Record the resulting issue ID or URL in `.architecture-guard/sync_status.json` (e.g., `{ "status": "success", "issue_url": "..." }`).
+   - If the push fails, write `{ "status": "failed" }` to `.architecture-guard/sync_status.json` and output a non-blocking warning. Do NOT stop the delivery workflow.
 7. If a previously approved User Story has been modified after engineering artifacts were generated, mark it `review-required`, warn the user, and require re-approval before proceeding.
 
 ## Phase 4 — Inspect Resume State

--- a/orchestration/init.md
+++ b/orchestration/init.md
@@ -433,6 +433,7 @@ If the user selects Team Development:
 1. Write `Mode: Team` into the governance rules (e.g., `openspec/config.yaml` or `.specify/memory/constitution.md`).
 2. Ask: "Which issue tracker MCP server should be used to sync User Stories? (e.g., github-mcp-server, jira, none)". Save this preference in the governance rules.
 3. Automatically scaffold a `user-stories/` directory at the project root to house global business requirements.
+4. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira). Then, automatically scaffold the `.architecture-guard/sync.yml` file configuring the chosen provider, the project/repo string, and `enabled: true`.
 
 ---
 


### PR DESCRIPTION
## Description
This PR introduces the User Story tracker synchronization capability and enhances the initialization workflow.

### Key Changes
- **Configuration Validation**: Added strict YAML schema validation via `zod` in `src/cli/validate-sync-config.ts` to ensure `.architecture-guard/sync.yml` inputs are sanitized.
- **Workflow Orchestration**: Enhanced `src/orchestration/governed-delivery-team.md` and `src/commands/governed-delivery-team.md` to trigger one-way tracker syncing via `github-mcp-server` upon User Story approval.
- **Init Scaffolding**: Integrated prompt updates in `src/commands/init.md` and `src/orchestration/init.md` to interactively scaffold the `sync.yml` configuration during team project initialization.
- **Documentation**: Added the User Story Tracker Sync feature to `src/docs/workflows.md` and updated `src/docs/release-notes.md`.

### Architecture Alignment
- Follows the Ponytail pragmatism principle by using the native orchestrator prompting for scaffolding and utilizing existing MCP extensions for remote synchronization, avoiding SDK bloat.

Closes #10