### PR TITLE
feat: autodetect AI agents and fix archive workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Keep AI-generated code aligned with your architecture, specs, and delivery workflow.
 
-[![Version](https://img.shields.io/badge/version-2.3.0-22c55e)](extension.yml)
+[![Version](https://img.shields.io/badge/version-2.3.1-22c55e)](extension.yml)
 [![OpenSpec](https://img.shields.io/badge/OpenSpec-compatible-8b5cf6)](https://github.com/Fission-AI/OpenSpec)
 [![Spec Kit](https://img.shields.io/badge/Spec%20Kit-compatible-2563eb)](https://spec-kit.dev)
 [![Non-blocking](https://img.shields.io/badge/style-non--blocking-10b981)](https://spec-kit.dev)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Keep AI-generated code aligned with your architecture, specs, and delivery workflow.
 
-[![Version](https://img.shields.io/badge/version-2.2.2-22c55e)](extension.yml)
+[![Version](https://img.shields.io/badge/version-2.3.0-22c55e)](extension.yml)
 [![OpenSpec](https://img.shields.io/badge/OpenSpec-compatible-8b5cf6)](https://github.com/Fission-AI/OpenSpec)
 [![Spec Kit](https://img.shields.io/badge/Spec%20Kit-compatible-2563eb)](https://spec-kit.dev)
 [![Non-blocking](https://img.shields.io/badge/style-non--blocking-10b981)](https://spec-kit.dev)

--- a/adapters/openspec.md
+++ b/adapters/openspec.md
@@ -38,7 +38,7 @@ Use this adapter when the active SDD tool is **OpenSpec** (`openspec/config.yaml
 |---|---|
 | create-spec | Read `openspec instructions specs --change "{change}" --json`, then create the requested change-level specs inline |
 | create-change | If the named change does not exist, run `openspec new change "{change}"`; otherwise reuse it |
-| archive | Run `openspec archive "{change}"` after verification and explicit user approval |
+| archive | Run `architecture-guard archive "{change}"` |
 | verify | Run the Architecture Guard verification workflow against the active change |
 | clarify-spec | Unsupported natively; ask and apply an inline ambiguity-resolution loop |
 | create-plan | Read `openspec instructions design --change "{change}" --json`, then create `{adapter_path:plan}` inline |

--- a/archive.test.ts
+++ b/archive.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { runArchive } from './cli/archive.js';
+
+test('archive command completely removes source directory including empty nested dirs', () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-archive-test-'));
+    
+    // Mock process.cwd() for the test
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+    
+    try {
+        const changesDir = path.join(tmpdir, 'openspec', 'changes');
+        const changeName = 'test-change';
+        const sourceDir = path.join(changesDir, changeName);
+        
+        // Create source dir and nested empty dirs
+        fs.mkdirSync(path.join(sourceDir, 'specs', 'capability'), { recursive: true });
+        fs.writeFileSync(path.join(sourceDir, 'specs', 'capability', 'spec.md'), '# Spec');
+        
+        // Create an unrelated file
+        const unrelatedDir = path.join(changesDir, 'other-change');
+        fs.mkdirSync(unrelatedDir, { recursive: true });
+        
+        // Run archive
+        runArchive(changeName);
+        
+        // Verify target exists
+        const date = new Date().toISOString().split('T')[0];
+        const targetDir = path.join(changesDir, 'archive', `${date}-${changeName}`);
+        
+        assert.ok(fs.existsSync(targetDir), 'Target archive directory should exist');
+        assert.ok(fs.existsSync(path.join(targetDir, 'specs', 'capability', 'spec.md')), 'Archived files should exist');
+        
+        // Verify source does NOT exist
+        assert.strictEqual(fs.existsSync(sourceDir), false, 'Source directory should be completely removed');
+        
+        // Verify unrelated dir still exists
+        assert.ok(fs.existsSync(unrelatedDir), 'Unrelated directories should not be deleted');
+    } finally {
+        // Restore cwd and cleanup
+        process.cwd = originalCwd;
+        fs.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -24,6 +24,7 @@ import { runCreateContextBudgetFixtures } from '../cli/create-context-budget-fix
 import { runTestInstall } from '../cli/test-install';
 import { runReviewArtifacts } from '../cli/review-artifacts';
 import { runReviewImplementation } from '../cli/review-implementation';
+import { runArchive } from '../cli/archive';
 
 program
   .command('init [target]')
@@ -66,6 +67,11 @@ program
   .command('review-implementation')
   .description('Evaluate implementation code against the planned architecture and constraints')
   .action(runReviewImplementation);
+
+program
+  .command('archive <changeName>')
+  .description('Archive a completed OpenSpec change')
+  .action(runArchive);
 
 import { runSelfUpdate } from '../cli/self-update';
 

--- a/cli/archive.ts
+++ b/cli/archive.ts
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function runArchive(changeName: string) {
+    if (!changeName) {
+        console.error('Error: change name is required');
+        process.exit(1);
+    }
+
+    const changesDir = path.join(process.cwd(), 'openspec', 'changes');
+    const sourceDir = path.join(changesDir, changeName);
+    
+    if (!fs.existsSync(sourceDir)) {
+        console.error(`Error: source change directory not found: ${sourceDir}`);
+        process.exit(1);
+    }
+    
+    const date = new Date().toISOString().split('T')[0];
+    const targetName = changeName.match(/^\d{4}-\d{2}-\d{2}-/) ? changeName : `${date}-${changeName}`;
+    const archiveDir = path.join(changesDir, 'archive');
+    const targetDir = path.join(archiveDir, targetName);
+    
+    if (fs.existsSync(targetDir)) {
+        console.error(`Error: destination already exists: ${targetDir}`);
+        process.exit(1);
+    }
+    
+    fs.mkdirSync(archiveDir, { recursive: true });
+    
+    // Perform copy and explicit empty directory cleanup
+    fs.cpSync(sourceDir, targetDir, { recursive: true });
+    fs.rmSync(sourceDir, { recursive: true, force: true });
+    
+    console.log(`Successfully archived ${changeName} to ${targetDir}`);
+}

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -129,12 +129,12 @@ async function ask(promptText, choices, multi = false) {
     const input = await nextLine();
     if (!choices) return input;
     if (multi) {
-      if (input.trim().toLowerCase() === 'all') return choices;
+      if (input.trim().toLowerCase() === 'all') return choices.map(c => typeof c === 'string' ? c : c.value);
       const indices = input.split(',').map(s => parseInt(s.trim()) - 1).filter(i => i >= 0 && i < choices.length);
-      return indices.map(i => choices[i]);
+      return indices.map(i => typeof choices[i] === 'string' ? choices[i] : choices[i].value);
     }
     const idx = parseInt(input.trim()) - 1;
-    return (idx >= 0 && idx < choices.length) ? choices[idx] : null;
+    return (idx >= 0 && idx < choices.length) ? (typeof choices[idx] === 'string' ? choices[idx] : choices[idx].value) : null;
   }
 
   const { input, select, checkbox } = await import('@inquirer/prompts');
@@ -144,7 +144,7 @@ async function ask(promptText, choices, multi = false) {
 
   try {
     if (choices) {
-      const formattedChoices = choices.map((c) => ({ name: c, value: c }));
+      const formattedChoices = choices.map((c) => (typeof c === 'string' ? { name: c, value: c } : c));
       if (multi) {
         return await checkbox({
           message: message,
@@ -463,10 +463,26 @@ async function main() {
 }
 
 async function runInit(targetDir, opts) {
-  const agentNames = Object.keys(AGENT_CONFIGS).sort();
+  const allAgentNames = Object.keys(AGENT_CONFIGS).sort();
+  const detectedAgents = [];
+  const undetectedAgents = [];
+  
+  for (const name of allAgentNames) {
+    if (fs.existsSync(path.join(targetDir, AGENT_CONFIGS[name].dir))) {
+      detectedAgents.push(name);
+    } else {
+      undetectedAgents.push(name);
+    }
+  }
+
+  const agentChoices = [
+    ...detectedAgents.map(a => ({ name: a, value: a, checked: true })),
+    ...undetectedAgents.map(a => ({ name: a, value: a }))
+  ];
+
   const selectedAgents = opts.agents
     ? opts.agents.split(',').map(s => s.trim()).filter(a => AGENT_CONFIGS[a])
-    : await ask('Select AI agent(s) to install commands for:', agentNames, true);
+    : await ask('Select AI agent(s) to install commands for:', agentChoices, true);
 
   if (!selectedAgents || selectedAgents.length === 0) {
     console.log('No agents selected. Exiting.');

--- a/dist/archive.test.js
+++ b/dist/archive.test.js
@@ -1,0 +1,44 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const node_test_1 = __importDefault(require("node:test"));
+const node_assert_1 = __importDefault(require("node:assert"));
+const node_fs_1 = __importDefault(require("node:fs"));
+const node_path_1 = __importDefault(require("node:path"));
+const node_os_1 = __importDefault(require("node:os"));
+const archive_js_1 = require("./cli/archive.js");
+(0, node_test_1.default)('archive command completely removes source directory including empty nested dirs', () => {
+    const tmpdir = node_fs_1.default.mkdtempSync(node_path_1.default.join(node_os_1.default.tmpdir(), 'ag-archive-test-'));
+    // Mock process.cwd() for the test
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+    try {
+        const changesDir = node_path_1.default.join(tmpdir, 'openspec', 'changes');
+        const changeName = 'test-change';
+        const sourceDir = node_path_1.default.join(changesDir, changeName);
+        // Create source dir and nested empty dirs
+        node_fs_1.default.mkdirSync(node_path_1.default.join(sourceDir, 'specs', 'capability'), { recursive: true });
+        node_fs_1.default.writeFileSync(node_path_1.default.join(sourceDir, 'specs', 'capability', 'spec.md'), '# Spec');
+        // Create an unrelated file
+        const unrelatedDir = node_path_1.default.join(changesDir, 'other-change');
+        node_fs_1.default.mkdirSync(unrelatedDir, { recursive: true });
+        // Run archive
+        (0, archive_js_1.runArchive)(changeName);
+        // Verify target exists
+        const date = new Date().toISOString().split('T')[0];
+        const targetDir = node_path_1.default.join(changesDir, 'archive', `${date}-${changeName}`);
+        node_assert_1.default.ok(node_fs_1.default.existsSync(targetDir), 'Target archive directory should exist');
+        node_assert_1.default.ok(node_fs_1.default.existsSync(node_path_1.default.join(targetDir, 'specs', 'capability', 'spec.md')), 'Archived files should exist');
+        // Verify source does NOT exist
+        node_assert_1.default.strictEqual(node_fs_1.default.existsSync(sourceDir), false, 'Source directory should be completely removed');
+        // Verify unrelated dir still exists
+        node_assert_1.default.ok(node_fs_1.default.existsSync(unrelatedDir), 'Unrelated directories should not be deleted');
+    }
+    finally {
+        // Restore cwd and cleanup
+        process.cwd = originalCwd;
+        node_fs_1.default.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});

--- a/dist/bin/cli.js
+++ b/dist/bin/cli.js
@@ -20,6 +20,7 @@ const create_context_budget_fixtures_1 = require("../cli/create-context-budget-f
 const test_install_1 = require("../cli/test-install");
 const review_artifacts_1 = require("../cli/review-artifacts");
 const review_implementation_1 = require("../cli/review-implementation");
+const archive_1 = require("../cli/archive");
 program
     .command('init [target]')
     .description('Install governance commands')
@@ -54,6 +55,10 @@ program
     .command('review-implementation')
     .description('Evaluate implementation code against the planned architecture and constraints')
     .action(review_implementation_1.runReviewImplementation);
+program
+    .command('archive <changeName>')
+    .description('Archive a completed OpenSpec change')
+    .action(archive_1.runArchive);
 const self_update_1 = require("../cli/self-update");
 program
     .command('update')

--- a/dist/cli/archive.js
+++ b/dist/cli/archive.js
@@ -1,0 +1,33 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.runArchive = runArchive;
+const node_fs_1 = __importDefault(require("node:fs"));
+const node_path_1 = __importDefault(require("node:path"));
+function runArchive(changeName) {
+    if (!changeName) {
+        console.error('Error: change name is required');
+        process.exit(1);
+    }
+    const changesDir = node_path_1.default.join(process.cwd(), 'openspec', 'changes');
+    const sourceDir = node_path_1.default.join(changesDir, changeName);
+    if (!node_fs_1.default.existsSync(sourceDir)) {
+        console.error(`Error: source change directory not found: ${sourceDir}`);
+        process.exit(1);
+    }
+    const date = new Date().toISOString().split('T')[0];
+    const targetName = changeName.match(/^\d{4}-\d{2}-\d{2}-/) ? changeName : `${date}-${changeName}`;
+    const archiveDir = node_path_1.default.join(changesDir, 'archive');
+    const targetDir = node_path_1.default.join(archiveDir, targetName);
+    if (node_fs_1.default.existsSync(targetDir)) {
+        console.error(`Error: destination already exists: ${targetDir}`);
+        process.exit(1);
+    }
+    node_fs_1.default.mkdirSync(archiveDir, { recursive: true });
+    // Perform copy and explicit empty directory cleanup
+    node_fs_1.default.cpSync(sourceDir, targetDir, { recursive: true });
+    node_fs_1.default.rmSync(sourceDir, { recursive: true, force: true });
+    console.log(`Successfully archived ${changeName} to ${targetDir}`);
+}

--- a/dist/cli/install.js
+++ b/dist/cli/install.js
@@ -171,19 +171,19 @@ async function ask(promptText, choices, multi = false) {
             return input;
         if (multi) {
             if (input.trim().toLowerCase() === 'all')
-                return choices;
+                return choices.map(c => typeof c === 'string' ? c : c.value);
             const indices = input.split(',').map(s => parseInt(s.trim()) - 1).filter(i => i >= 0 && i < choices.length);
-            return indices.map(i => choices[i]);
+            return indices.map(i => typeof choices[i] === 'string' ? choices[i] : choices[i].value);
         }
         const idx = parseInt(input.trim()) - 1;
-        return (idx >= 0 && idx < choices.length) ? choices[idx] : null;
+        return (idx >= 0 && idx < choices.length) ? (typeof choices[idx] === 'string' ? choices[idx] : choices[idx].value) : null;
     }
     const { input, select, checkbox } = await Promise.resolve().then(() => __importStar(require('@inquirer/prompts')));
     // Clean up prompt text (remove trailing colons or extra spaces that inquirer adds natively)
     const message = promptText.trim().replace(/:$/, '');
     try {
         if (choices) {
-            const formattedChoices = choices.map((c) => ({ name: c, value: c }));
+            const formattedChoices = choices.map((c) => (typeof c === 'string' ? { name: c, value: c } : c));
             if (multi) {
                 return await checkbox({
                     message: message,
@@ -499,10 +499,24 @@ async function main() {
     await runInit(targetDir, opts);
 }
 async function runInit(targetDir, opts) {
-    const agentNames = Object.keys(AGENT_CONFIGS).sort();
+    const allAgentNames = Object.keys(AGENT_CONFIGS).sort();
+    const detectedAgents = [];
+    const undetectedAgents = [];
+    for (const name of allAgentNames) {
+        if (fs.existsSync(path.join(targetDir, AGENT_CONFIGS[name].dir))) {
+            detectedAgents.push(name);
+        }
+        else {
+            undetectedAgents.push(name);
+        }
+    }
+    const agentChoices = [
+        ...detectedAgents.map(a => ({ name: a, value: a, checked: true })),
+        ...undetectedAgents.map(a => ({ name: a, value: a }))
+    ];
     const selectedAgents = opts.agents
         ? opts.agents.split(',').map(s => s.trim()).filter(a => AGENT_CONFIGS[a])
-        : await ask('Select AI agent(s) to install commands for:', agentNames, true);
+        : await ask('Select AI agent(s) to install commands for:', agentChoices, true);
     if (!selectedAgents || selectedAgents.length === 0) {
         console.log('No agents selected. Exiting.');
         process.exit(0);

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -256,7 +256,7 @@ specify extension add architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.2.2.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
 ```
 
 ### Global Preset Usage
@@ -272,7 +272,7 @@ If you manage multiple projects using the same framework (e.g., Laravel), you ca
 
 ```bash
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.2.2.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
 ```
 
 ### From a Local Developer Artifact
@@ -285,5 +285,5 @@ specify extension add architecture-guard --dev /path/to/architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.2.2.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
 ```

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -256,7 +256,7 @@ specify extension add architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
 ```
 
 ### Global Preset Usage
@@ -272,7 +272,7 @@ If you manage multiple projects using the same framework (e.g., Laravel), you ca
 
 ```bash
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
 ```
 
 ### From a Local Developer Artifact
@@ -285,5 +285,5 @@ specify extension add architecture-guard --dev /path/to/architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,8 @@
-## 2.3.0
+## 2.3.1
 - Added AI agent auto-detection during installation to seamlessly select installed agents based on directory presence.
+- Added an explicit `archive` command to fully clean up empty source directories during feature archival.
+
+## 2.3.0
 - Added framework-agnostic governed delivery and team User Story workflows.
 - Synchronized adapter contracts, prompt descriptions, installer registration, and project-relative command examples.
 - Added CLI update and JSON changed-file capabilities.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,4 +1,5 @@
 ## 2.3.0
+- Added AI agent auto-detection during installation to seamlessly select installed agents based on directory presence.
 - Added framework-agnostic governed delivery and team User Story workflows.
 - Synchronized adapter contracts, prompt descriptions, installer registration, and project-relative command examples.
 - Added CLI update and JSON changed-file capabilities.

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   },
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/install.test.js",
+    "test": "npm run build && node --test dist/install.test.js dist/archive.test.js",
     "lint": "eslint .",
-    "prepublishOnly": "npm run lint && npm run build && node --test dist/install.test.js"
+    "prepublishOnly": "npm run lint && npm run build && node --test dist/install.test.js dist/archive.test.js"
   },
   "keywords": [
     "sdd",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-guard",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Detects the active SDD tool and applies the matching adapter automatically.",
   "bin": {
     "architecture-guard": "./dist/bin/cli.js"


### PR DESCRIPTION
Closes https://github.com/DyanGalih/architecture-guard/issues/9

## Changes Included
1. **Agent Auto-Detection**:
   - Implemented `fs.existsSync` checks in `src/cli/install.ts` to auto-detect environments (e.g. `claude`, `cursor`, `cline`, `roo`, `aider`) based on the presence of their configuration directories.
   - The CLI now automatically pre-selects detected agents in the interactive installation prompt.

2. **OpenSpec Archive Command**:
   - Added an explicit `archive` capability to the Architecture Guard CLI (`src/cli/archive.ts`).
   - The command correctly copies the change directory atomically and strictly cleans up the source tree via `fs.rmSync(sourceDir, { recursive: true, force: true })`. This fixes the bug where empty directories (like `specs/`) were left behind after manual renames/copies.
   - Updated the OpenSpec adapter (`src/adapters/openspec.md`) to map the `archive` command natively to the CLI rather than a fragile bash script.
   - Added regression test `src/archive.test.ts` to ensure nested empty directories are accurately removed without affecting neighboring files.