### PR TITLE
fix: declare sync config dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Keep AI-generated code aligned with your architecture, specs, and delivery workflow.
 
-[![Version](https://img.shields.io/badge/version-2.3.1-22c55e)](extension.yml)
+[![Version](https://img.shields.io/badge/version-2.3.2-22c55e)](extension.yml)
 [![OpenSpec](https://img.shields.io/badge/OpenSpec-compatible-8b5cf6)](https://github.com/Fission-AI/OpenSpec)
 [![Spec Kit](https://img.shields.io/badge/Spec%20Kit-compatible-2563eb)](https://spec-kit.dev)
 [![Non-blocking](https://img.shields.io/badge/style-non--blocking-10b981)](https://spec-kit.dev)

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -256,7 +256,7 @@ specify extension add architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.2.zip
 ```
 
 ### Global Preset Usage
@@ -272,7 +272,7 @@ If you manage multiple projects using the same framework (e.g., Laravel), you ca
 
 ```bash
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.2.zip
 ```
 
 ### From a Local Developer Artifact
@@ -285,5 +285,5 @@ specify extension add architecture-guard --dev /path/to/architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.1.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.2.zip
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,6 @@
+## 2.3.2
+- Fixed the sync-config validator build by declaring its `yaml` and `zod` runtime dependencies.
+
 ## 2.3.1
 - Added AI agent auto-detection during installation to seamlessly select installed agents based on directory presence.
 - Added an explicit `archive` command to fully clean up empty source directories during feature archival.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-guard",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Detects the active SDD tool and applies the matching adapter automatically.",
   "bin": {
     "architecture-guard": "./dist/bin/cli.js"
@@ -52,7 +52,9 @@
   ],
   "dependencies": {
     "@inquirer/prompts": "^8.5.2",
-    "commander": "^15.0.0"
+    "commander": "^15.0.0",
+    "yaml": "^2.9.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,12 @@ importers:
       commander:
         specifier: ^15.0.0
         version: 15.0.0
+      yaml:
+        specifier: ^2.9.0
+        version: 2.9.0
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
@@ -601,9 +607,17 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1146,4 +1160,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  yaml@2.9.0: {}
+
   yocto-queue@0.1.0: {}
+
+  zod@4.4.3: {}


### PR DESCRIPTION
## Summary
- Declare `yaml` and `zod` as runtime dependencies required by `cli/validate-sync-config.ts`.
- Restore successful TypeScript builds for the sync-config validator.
- Bump the patch release to `2.3.2` and synchronize README, reference-manual download URLs, and release notes.

## Root cause
`cli/validate-sync-config.ts` imported `yaml` and `zod`, but neither package was listed in `package.json`, causing `npm run build` to fail with TypeScript module-resolution errors.

## Validation
- `pnpm --dir src run build`

Fixes #9