### PR TITLE
fix: include proposal.md in artifact references across commands

### DIFF
--- a/adapters/generic.md
+++ b/adapters/generic.md
@@ -46,7 +46,7 @@ Use this adapter when no supported SDD tool is selected. Ask the user for active
 | subagent-synthesize | Use host delegation when available; otherwise synthesize inline |
 | list-specs | Ask the user which historical specifications are relevant |
 | consolidate-specs | Unsupported; do not write a fallback index |
-| architecture-apply | Use the registered architecture-apply capability or update selected artifacts inline |
+| architecture-apply | Apply plan/tasks findings directly inline; run inline AG-native artifact-fix for upstream findings after user confirmation |
 | architecture-review | Use the registered architecture-review capability or review selected artifacts inline |
 | refactor-generator | Use the registered refactor-generator capability or generate refactor tasks inline |
 | violation-detection | Use the registered violation-detection capability or detect drift inline |

--- a/adapters/openspec.md
+++ b/adapters/openspec.md
@@ -52,7 +52,7 @@ Use this adapter when the active SDD tool is **OpenSpec** (`openspec/config.yaml
 | subagent-synthesize | Unsupported natively; synthesize inline unless the host exposes an equivalent capability |
 | list-specs | `openspec list --specs --json` |
 | consolidate-specs | Unsupported: use `list-specs` as the fallback index and do not write a consolidated artifact |
-| architecture-apply | Use the registered architecture-apply capability; otherwise update the resolved plan and tasks inline |
+| architecture-apply | Apply plan/tasks findings directly inline; delegate upstream findings (`proposal.md`, `spec.md`) to `openspec-update-change` (or native update capability) with finding details as input context after user confirmation |
 | architecture-review | Use the registered architecture-review capability or review the resolved artifacts inline |
 | refactor-generator | Use the registered refactor-generator capability or generate refactor tasks inline |
 | violation-detection | Use the registered violation-detection capability or detect drift inline |

--- a/adapters/spec-kit.md
+++ b/adapters/spec-kit.md
@@ -50,7 +50,7 @@ Use this adapter when the active SDD tool is **Spec Kit** (`.specify/` directory
 | subagent-synthesize | `/speckit.subagent.synthesize` when registered; otherwise synthesize inline |
 | list-specs | Enumerate files matching `{adapter_path:spec}` in normalized path order |
 | consolidate-specs | Build `{adapter_path:fallback-spec-index}` inline from `list-specs` results |
-| architecture-apply | Use the registered architecture-apply capability; otherwise update the resolved plan and tasks inline |
+| architecture-apply | Apply plan/tasks findings directly inline; after confirmation, use an explicit host update capability when available, otherwise run the AG-native inline artifact-fix against the resolved `spec.md` path; do not invoke `/speckit.specify` for updates |
 | architecture-review | Use the registered architecture-review capability or review the resolved artifacts inline |
 | refactor-generator | Use the registered refactor-generator capability or generate refactor tasks inline |
 | violation-detection | Use the registered violation-detection capability or detect drift inline |

--- a/commands/apply.md
+++ b/commands/apply.md
@@ -14,7 +14,7 @@ If `flash-mem` is available, use the MCP-backed context preparation flow exposed
 
 This is the write-capable companion to the review workflow. Use it when the team wants the architecture feedback reflected directly in planning artifacts instead of only receiving suggestions.
 
-Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in design or task artifacts (e.g., `plan.md`, `design.md`, `tasks.md`).
+Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in design or task artifacts (the exact filenames depend on the active SDD tool).
 
 Use it for approved Constitution Update Proposals when the change should be reflected in plan or task artifacts as explicit follow-up work.
 
@@ -24,7 +24,7 @@ You may update plan and task artifacts, but you must keep the changes small, tar
 
 You may revise:
 
-- `plan.md`
+- the technical design artifact
 - `tasks.md`
 - Related task breakdown or checklist artifacts when they are part of the same Spec Kit workflow
 
@@ -51,7 +51,7 @@ Review any available:
 
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in design or task artifacts (e.g., `plan.md`, `design.md`, `tasks.md`).
+1. Identify the approved architecture changes that should be reflected in design or task artifacts (the exact filenames depend on the active SDD tool).
 2. Preserve the feature intent and implementation scope.
 3. Add or refine task entries for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.

--- a/commands/apply.md
+++ b/commands/apply.md
@@ -22,14 +22,14 @@ You may update plan and task artifacts, but you must keep the changes small, tar
 
 ## Allowed Edits
 
-You may revise:
-
-- the technical design artifact
+You may revise directly:
+- the technical design artifact (`plan.md` / `design.md`)
 - `tasks.md`
 - Related task breakdown or checklist artifacts when they are part of the same Spec Kit workflow
 
-You should not:
+For findings targeting upstream artifacts (`proposal.md`, `spec.md`), `ag-apply` acts as an orchestrator and delegates those fixes to the SDD tool's native update capability (or runs an inline AG-native fallback) upon user confirmation. `ag-apply` does NOT edit upstream artifacts directly.
 
+You should not:
 - Rewrite the whole plan unnecessarily.
 - Remove product intent or feature scope.
 - Introduce framework-specific rules into the core workflow.
@@ -38,8 +38,7 @@ You should not:
 ## Inputs To Consider
 
 Review any available:
-
-- Existing architecture review output.
+- Existing architecture review output (including `Target:` fields for finding classification).
 - Approved refactor tasks.
 - Constitution rules.
 - Feature specification.
@@ -49,18 +48,39 @@ Review any available:
 - Optional preset guidance, if available.
 - Approved Constitution Update Proposals, if present.
 
+## Finding Partitioning
+
+Before executing edits, `ag-apply` partitions all review findings into two distinct groups based on their `Target:` field:
+
+1. **Plan/Tasks Group**: Findings targeting the adapter-resolved planning artifact (`plan.md` for SpecKit, `design.md` for OpenSpec/generic projects that use that name) or `tasks.md`.
+2. **Upstream Group**: Findings targeting `proposal.md` or `spec.md`.
+
+For multi-artifact findings, resolution is performed in authoritative order (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`), fixing the authoritative artifact first and propagating downstream.
+
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in design or task artifacts (the exact filenames depend on the active SDD tool).
-2. Preserve the feature intent and implementation scope.
-3. Add or refine task entries for refactors that are safe to schedule.
+### Step 1: Direct Apply for Plan/Tasks Group
+1. Process all findings in the **Plan/Tasks Group** directly.
+2. Preserve feature intent and implementation scope.
+3. Add or refine task entries in `tasks.md` for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.
-5. Update plan language so boundaries, contracts, and ownership are explicit.
+5. Update plan/design language so boundaries, contracts, and ownership are explicit.
 6. Keep implementation moving unless the Constitution explicitly says the issue is blocking.
-7. If a refactor is too large for the current scope, create a scoped task rather than expanding the whole plan.
+7. If a refactor is too large for current scope, create a scoped task rather than expanding the whole plan.
 8. If an approved Constitution Update Proposal exists, reflect it as explicit follow-up work without auto-changing the Constitution itself.
-9. If the surrounding workflow emits a token-savings banner, leave it visible while applying the approved changes.
-10. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
+9. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
+
+### Step 2: Confirmation for Upstream Group
+If the **Upstream Group** contains findings:
+1. Present a grouped summary table of upstream findings organized by target artifact (`proposal.md`, `spec.md`).
+2. Prompt the user for confirmation: `"Proceed with upstream artifact fixes? [Y/n]"`
+3. If the user declines/rejects, mark all upstream findings as `skipped` in the final report and exit early.
+
+### Step 3: Upstream Delegation / Fallback Execution
+Upon user confirmation for the **Upstream Group**:
+1. **Native Delegation**: If the active SDD tool exposes a native update capability (e.g. `openspec-update-change` in OpenSpec), delegate the upstream findings to that capability with finding details as input context.
+2. **AG-Native Fallback**: If the active SDD tool lacks a native update capability (e.g. generic mode), execute an inline AG-native artifact-fix following the exact same confirmation and authoritative-first ordering.
+3. **Propagation**: Ensure fixes are applied in authoritative order (`spec.md` first, then the adapter-resolved planning artifact, then `tasks.md` for coherence).
 
 ## Write-Back Rules
 
@@ -72,4 +92,24 @@ Review any available:
 
 ## Output Format
 
-Return the changed artifact summary and the updated planning content in the standard Spec Kit artifact format.
+Return a unified summary report covering both direct edits and delegated upstream fixes:
+
+```markdown
+# Architecture Apply Summary
+
+## Direct Edits (Plan / Tasks)
+- **Status**: [Applied / Skipped / None Needed]
+- **Modified Artifacts**: [e.g. design.md, tasks.md]
+- **Applied Findings**: [List of applied plan/tasks findings]
+
+## Delegated Upstream Edits (Proposal / Spec)
+- **Status**: [Applied / Delegated / Skipped by User / No Upstream Findings]
+- **Delegation Target**: [Native capability name or AG-Native Fallback]
+- **Upstream Findings**:
+  | ID | Target | Finding | Status |
+  |:---|:---|:---|:---|
+  | V1 | `spec.md` | ... | Applied / Skipped |
+
+## Next Step
+- [e.g. Continue to implementation or run verification]
+```

--- a/commands/consolidate-specs.md
+++ b/commands/consolidate-specs.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Purpose
 
-Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, or constitutions.
+Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, or constitutions.
 
 ## Procedure
 

--- a/commands/consolidate-specs.md
+++ b/commands/consolidate-specs.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Purpose
 
-Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), security constraints, or constitutions.
+Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, or constitutions.
 
 ## Procedure
 

--- a/commands/consolidate-specs.md
+++ b/commands/consolidate-specs.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Purpose
 
-Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, or constitutions.
+Generate `specs/system_context.md` as a compact offline fallback for Budgeted Architecture Context Retrieval. This file supplements active feature artifacts; it is not a canonical specification and must never replace the active active specification, design, and task artifacts (the exact filenames depend on the active SDD tool), security constraints, or constitutions.
 
 ## Procedure
 

--- a/commands/governed-delivery-team.md
+++ b/commands/governed-delivery-team.md
@@ -101,7 +101,7 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 6 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 

--- a/commands/governed-delivery-team.md
+++ b/commands/governed-delivery-team.md
@@ -101,11 +101,11 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 6 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), the technical design artifact, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: the design artifact (`plan.md`, `design.md`, or `proposal.md`) does not exist or is empty.
+- `missing`: the design artifact (the technical design artifact, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
@@ -123,7 +123,7 @@ Do not use timestamps as the only evidence of material staleness. Compare artifa
 ## Phase 7 — Plan Gate
 
 If the plan is `missing` or `stale`, execute the full `/ag-governed-plan` (or `/ag-governed-plan`) workflow.
-- **Linkage metadata**: When generating the new technical plan (`plan.md`, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
+- **Linkage metadata**: When generating the new technical plan (the technical design artifact, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
 If the plan is `review-required`, reuse it and run the applicable security plan review plus `/ag-review-artifacts`. Do not regenerate a plan merely because review is needed.
 

--- a/commands/governed-delivery-team.md
+++ b/commands/governed-delivery-team.md
@@ -101,11 +101,11 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 6 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: the design artifact (`plan.md` or `design.md`) does not exist or is empty.
+- `missing`: the design artifact (`plan.md`, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
@@ -123,7 +123,7 @@ Do not use timestamps as the only evidence of material staleness. Compare artifa
 ## Phase 7 — Plan Gate
 
 If the plan is `missing` or `stale`, execute the full `/ag-governed-plan` (or `/ag-governed-plan`) workflow.
-- **Linkage metadata**: When generating the new technical plan (`plan.md` or `design.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
+- **Linkage metadata**: When generating the new technical plan (`plan.md`, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
 If the plan is `review-required`, reuse it and run the applicable security plan review plus `/ag-review-artifacts`. Do not regenerate a plan merely because review is needed.
 

--- a/commands/governed-delivery.md
+++ b/commands/governed-delivery.md
@@ -76,11 +76,11 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 5 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: the design artifact (`plan.md` or `design.md`) does not exist or is empty.
+- `missing`: the design artifact (`plan.md`, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.

--- a/commands/governed-delivery.md
+++ b/commands/governed-delivery.md
@@ -76,7 +76,7 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 5 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 

--- a/commands/governed-delivery.md
+++ b/commands/governed-delivery.md
@@ -76,11 +76,11 @@ Check if a formal specification or proposal already exists for the active featur
 
 ## Phase 5 — Inspect Resume State
 
-Inspect `spec.md` (or equivalent specification artifacts), `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md` (or equivalent specification artifacts), the technical design artifact, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: the design artifact (`plan.md`, `design.md`, or `proposal.md`) does not exist or is empty.
+- `missing`: the design artifact (the technical design artifact, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.

--- a/commands/governed-implement.md
+++ b/commands/governed-implement.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active feature's `tasks.md` is mandatory and authoritative; load its active design and specification artifacts (e.g., `plan.md`, `design.md`, `spec.md`), and security constraints whenever a task lacks enough context. Flash-Mem and `system_context.md` may supplement but never replace active artifacts.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active feature's `tasks.md` is mandatory and authoritative; load its active design and specification artifacts (e.g., the technical design artifact, `design.md`, `spec.md`), and security constraints whenever a task lacks enough context. Flash-Mem and `system_context.md` may supplement but never replace active artifacts.
 
 You are orchestrating the `ag-governed-implement` workflow for `architecture-guard`.
 

--- a/commands/governed-plan.md
+++ b/commands/governed-plan.md
@@ -101,7 +101,7 @@ Run:
 ```
 
 Inputs to consider:
-- The generated technical design document (e.g., `plan.md` or `design.md`).
+- The generated technical design document (e.g., `plan.md`, `design.md`, or `proposal.md`).
 - `.specify/memory/architecture_constitution.md`.
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).

--- a/commands/governed-plan.md
+++ b/commands/governed-plan.md
@@ -101,7 +101,7 @@ Run:
 ```
 
 Inputs to consider:
-- The generated technical design document (e.g., `plan.md`, `design.md`, or `proposal.md`).
+- The generated technical design document (the exact filename depends on the active SDD tool).
 - `.specify/memory/architecture_constitution.md`.
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).

--- a/commands/governed-tasks.md
+++ b/commands/governed-tasks.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active feature's specification and design artifacts (e.g., `spec.md`, `design.md`, `plan.md`), and applicable constitutions are mandatory and authoritative. Flash-Mem and `system_context.md` may supplement but never replace them.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active feature's specification and design artifacts (e.g., `spec.md`, `design.md`, the technical design artifact), and applicable constitutions are mandatory and authoritative. Flash-Mem and `system_context.md` may supplement but never replace them.
 
 You are orchestrating the `ag-governed-tasks` workflow for `architecture-guard`.
 

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (the exact filenames depend on the active SDD tool) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (the exact filenames depend on the active SDD tool)
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
@@ -144,7 +144,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
 **Absence Evidence** is acceptable for CRITICAL violations only. Example:
-- "Constitution requires data access abstraction but `plan.md` (or `proposal.md`) does not specify one"
+- "Constitution requires data access abstraction but the technical design artifact does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
 

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
@@ -144,7 +144,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
 **Absence Evidence** is acceptable for CRITICAL violations only. Example:
-- "Constitution requires data access abstraction but `plan.md` does not specify one"
+- "Constitution requires data access abstraction but `plan.md` (or `proposal.md`) does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
 

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -127,13 +127,14 @@ Detect violations such as:
 2. **Model Context**: Build Semantic Models for the identified scope.
 3. **Analyze Alignment**: Compare the initial specification intent vs. the proposed architectural design. Ensure the proposed design or plan accurately satisfies the spec without violating constraints.
 4. **Scan Principles**: Apply Review Principles across the planned boundaries.
-5. **Security & Governance Cross-Check**:
+5. **Target Classification**: Determine which artifact each finding targets based on the finding's source evidence. Emit the adapter-resolved filename: `plan.md` for SpecKit planning artifacts, `design.md` for OpenSpec design artifacts, and the applicable `proposal.md`, `spec.md`, or `tasks.md` otherwise. For multi-artifact findings, set `Target:` to the authoritative artifact (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`).
+6. **Security & Governance Cross-Check**:
   - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
   - Cross-reference architecture decisions with security trust boundaries.
-6. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
-7. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
-8. **Repository Hygiene Scan**: Evaluate the planning structure against hygiene rules loaded from `.specify/extensions/architecture-guard/hygiene-rules/*.md`.
-9. **Generate Refactors**: Produce structured tasks for each confirmed violation in the plan.
+7. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
+8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
+9. **Repository Hygiene Scan**: Evaluate the planning structure against hygiene rules loaded from `.specify/extensions/architecture-guard/hygiene-rules/*.md`.
+10. **Generate Refactors**: Produce structured tasks for each confirmed violation in the plan.
 
 ---
 
@@ -163,9 +164,9 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `.specify/memory/architecture_constitution.md` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
+| ID | Category | Severity | Location(s) | Target | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | `.specify/memory/architecture_constitution.md` | `plan.md` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
 
 ### Task Synchronization
 - **Status**: [Synced / Drifted]
@@ -217,7 +218,7 @@ Findings categorized by severity based on the active hygiene rules.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
 4. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
-5. **Next Step**: [e.g. Run `/speckit.security-review.plan` for security-first findings, or `/ag-apply` for architecture fixes]
+5. **Next Step**: Run `/ag-apply` to resolve all findings (plan/tasks findings will be applied directly; upstream findings in `proposal.md` or `spec.md` will be delegated with confirmation).
 6. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 
 ## Framework Preset Guidance

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (the exact filenames depend on the active SDD tool)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -87,10 +87,10 @@ Build internal representations:
 
 ## Verification Report
 
-| ID | Category | Severity | Location(s) | Summary | Recommendation |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
-| V2 | Boundary | HIGH | `ctrl/user.ts` | Database query found in Controller layer | Move query to Repository/Data layer |
+| ID | Category | Severity | Location(s) | Target | Summary | Recommendation |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
+| V2 | Boundary | HIGH | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
 
 ### Task Status Analysis
 For each task in `tasks.md`:

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
 
 Validate that the implementation fulfills all tasks in `tasks.md` while adhering to the defined architecture boundaries and the **Architecture Constitution**. This command acts as a post-implementation gate.
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (the exact filenames depend on the active SDD tool), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
 
 Validate that the implementation fulfills all tasks in `tasks.md` while adhering to the defined architecture boundaries and the **Architecture Constitution**. This command acts as a post-implementation gate.
 
@@ -45,7 +45,7 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 Build internal representations:
 - **Task-Boundary Map**: Associate each task with its intended architecture layer (Entry, Application, Domain, Data, External).
 - **Implementation Evidence**: For each completed task (`[x]`), scan referenced files for logic that addresses the task description.
-- **Contract Inventory**: Extract planned API/Data signatures from the design artifact (`plan.md`, `design.md`, or `proposal.md`).
+- **Contract Inventory**: Extract planned API/Data signatures from the design artifact (the technical design artifact, `design.md`, or `proposal.md`).
 - **Duplication Check**: Look for repeated business logic, validation, or transformation across files and confirm it has been centralized or explicitly justified.
 
 **Common DRY Signals**

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `.specify/extensions/architecture
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). The active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), applicable constitutions, security constraints, and code evidence are mandatory and authoritative. Neither Flash-Mem nor `system_context.md` is evidence that a task was implemented.
 
 Validate that the implementation fulfills all tasks in `tasks.md` while adhering to the defined architecture boundaries and the **Architecture Constitution**. This command acts as a post-implementation gate.
 
@@ -45,7 +45,7 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 Build internal representations:
 - **Task-Boundary Map**: Associate each task with its intended architecture layer (Entry, Application, Domain, Data, External).
 - **Implementation Evidence**: For each completed task (`[x]`), scan referenced files for logic that addresses the task description.
-- **Contract Inventory**: Extract planned API/Data signatures from the design artifact (`plan.md` or `design.md`).
+- **Contract Inventory**: Extract planned API/Data signatures from the design artifact (`plan.md`, `design.md`, or `proposal.md`).
 - **Duplication Check**: Look for repeated business logic, validation, or transformation across files and confirm it has been centralized or explicitly justified.
 
 **Common DRY Signals**

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -74,7 +74,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `specs/<feature>/security-constraints.md`
-   - active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), `data-model.md`
+   - active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -74,7 +74,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `specs/<feature>/security-constraints.md`
-   - active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), `data-model.md`
+   - active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -74,7 +74,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `specs/<feature>/security-constraints.md`
-   - active specification, design, and task artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), `data-model.md`
+   - active specification, design, and task artifacts (the exact filenames depend on the active SDD tool), `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -120,7 +120,7 @@ Outputs:
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md`, `proposal.md`, and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into `plan.md` (or `proposal.md`) and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
 
 ### Greenfield Quick Start
 
@@ -156,7 +156,7 @@ ag-workflow
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md`, `proposal.md`, and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into `plan.md` (or `proposal.md`) and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
 
 
 ## Commands
@@ -218,7 +218,7 @@ optimizer:
 
 > Use `ag-governed-delivery` as the suggested plan-to-tasks flow. Use `ag-workflow`, `ag-review-artifacts` or `ag-review-implementation` directly for standalone reviews; the individual `ag-governed-plan` and `ag-governed-tasks` commands remain available for targeted recovery.
 
-> `ag-apply` targets `plan.md`, `proposal.md`, and `tasks.md`. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
+> `ag-apply` targets `plan.md` (or `proposal.md`) and `tasks.md`. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
 
 ## Budgeted Architecture Context Retrieval
 

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -120,7 +120,7 @@ Outputs:
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md` (or `proposal.md`) and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into the technical design and task artifacts so the AI has explicit guidance to fix architectural debt while implementing features.
 
 ### Greenfield Quick Start
 
@@ -156,7 +156,7 @@ ag-workflow
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md` (or `proposal.md`) and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into the technical design and task artifacts so the AI has explicit guidance to fix architectural debt while implementing features.
 
 
 ## Commands
@@ -176,7 +176,7 @@ This injects refactor tasks into `plan.md` (or `proposal.md`) and `tasks.md` so 
 | `ag-review-implementation` | Validation | Validates implementation codebase against planning artifacts and constitution | After `/implement` |
 | `violation-detection` | Detection | Drift summary, boundary violations, module coupling | Focus on specific architecture problems |
 | `refactor-generator` | Planning | Refactor task generation | After review; convert violations to non-blocking refactor tasks |
-| `ag-apply` | Implementation | After refactor decisions | Inject refactor tasks into `tasks.md` and `plan.md` using the approved review context |
+| `ag-apply` | Implementation | After refactor decisions | Inject refactor tasks into `tasks.md` and the technical design artifact using the approved review context |
 | `ag-verify` | Verification | Implementation verification report with task fulfillment, architecture, and hygiene findings | Final gate after implementation to ensure all tasks are delivered, with cached memory context if available |
 
 ### Ponytail Core
@@ -218,7 +218,7 @@ optimizer:
 
 > Use `ag-governed-delivery` as the suggested plan-to-tasks flow. Use `ag-workflow`, `ag-review-artifacts` or `ag-review-implementation` directly for standalone reviews; the individual `ag-governed-plan` and `ag-governed-tasks` commands remain available for targeted recovery.
 
-> `ag-apply` targets `plan.md` (or `proposal.md`) and `tasks.md`. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
+> `ag-apply` targets the technical design and task artifacts. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
 
 ## Budgeted Architecture Context Retrieval
 

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -120,7 +120,7 @@ Outputs:
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md` and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into `plan.md`, `proposal.md`, and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
 
 ### Greenfield Quick Start
 
@@ -156,7 +156,7 @@ ag-workflow
 ag-apply
 ```
 
-This injects refactor tasks into `plan.md` and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
+This injects refactor tasks into `plan.md`, `proposal.md`, and `tasks.md` so the AI has explicit guidance to fix architectural debt while implementing features.
 
 
 ## Commands
@@ -218,7 +218,7 @@ optimizer:
 
 > Use `ag-governed-delivery` as the suggested plan-to-tasks flow. Use `ag-workflow`, `ag-review-artifacts` or `ag-review-implementation` directly for standalone reviews; the individual `ag-governed-plan` and `ag-governed-tasks` commands remain available for targeted recovery.
 
-> `ag-apply` targets `plan.md` and `tasks.md`. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
+> `ag-apply` targets `plan.md`, `proposal.md`, and `tasks.md`. If architectural issues are found in the specification stage, refine the specification before generating a technical plan. When `flash-mem` is available, use the cached synthesis and approved review output before writing back.
 
 ## Budgeted Architecture Context Retrieval
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -24,7 +24,7 @@
 
 ## 2.1.0
 - Rebuilt installer as a unified TypeScript CLI (`cli.ts`).
-- Generalized command prompts to support both SpecKit (`spec.md`, `plan.md`) and OpenSpec (`design.md`) artifacts natively.
+- Generalized command prompts to support both SpecKit (`spec.md`, the technical design artifact) and OpenSpec (`design.md`) artifacts natively.
 - Fixed command prompt prefixing to consistently use `.ag-` for extensions and `ag-` for standalone environments.
 - Added explicit Pre-Implementation and Post-Implementation review gates in the documentation workflows.
 

--- a/orchestration/apply.md
+++ b/orchestration/apply.md
@@ -20,7 +20,7 @@ If `flash-mem` is available, use the MCP-backed context preparation flow exposed
 
 This is the write-capable companion to the review workflow. Use it when the team wants the architecture feedback reflected directly in planning artifacts instead of only receiving suggestions.
 
-Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in `plan.md`, `proposal.md`, or `tasks.md`.
+Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in `plan.md` (or `proposal.md`) or `tasks.md`.
 
 Use it for approved Constitution Update Proposals when the change should be reflected in plan or task artifacts as explicit follow-up work.
 
@@ -57,7 +57,7 @@ Review any available:
 
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in `plan.md`, `proposal.md`, or `tasks.md`.
+1. Identify the approved architecture changes that should be reflected in `plan.md` (or `proposal.md`) or `tasks.md`.
 2. Preserve the feature intent and implementation scope.
 3. Add or refine task entries for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.

--- a/orchestration/apply.md
+++ b/orchestration/apply.md
@@ -20,7 +20,7 @@ If `flash-mem` is available, use the MCP-backed context preparation flow exposed
 
 This is the write-capable companion to the review workflow. Use it when the team wants the architecture feedback reflected directly in planning artifacts instead of only receiving suggestions.
 
-Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in `plan.md` or `tasks.md`.
+Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in `plan.md`, `proposal.md`, or `tasks.md`.
 
 Use it for approved Constitution Update Proposals when the change should be reflected in plan or task artifacts as explicit follow-up work.
 
@@ -57,7 +57,7 @@ Review any available:
 
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in `plan.md` or `tasks.md`.
+1. Identify the approved architecture changes that should be reflected in `plan.md`, `proposal.md`, or `tasks.md`.
 2. Preserve the feature intent and implementation scope.
 3. Add or refine task entries for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.

--- a/orchestration/apply.md
+++ b/orchestration/apply.md
@@ -20,7 +20,7 @@ If `flash-mem` is available, use the MCP-backed context preparation flow exposed
 
 This is the write-capable companion to the review workflow. Use it when the team wants the architecture feedback reflected directly in planning artifacts instead of only receiving suggestions.
 
-Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in `plan.md` (or `proposal.md`) or `tasks.md`.
+Use it after `ag-review-artifacts`, `ag-review-implementation` or `ag-violation-detection` has produced approved refactor tasks, or when a Constitution Update Proposal should be reflected in the technical design or task artifacts.
 
 Use it for approved Constitution Update Proposals when the change should be reflected in plan or task artifacts as explicit follow-up work.
 
@@ -30,7 +30,7 @@ You may update plan and task artifacts, but you must keep the changes small, tar
 
 You may revise:
 
-- `plan.md`
+- the technical design artifact
 - `tasks.md`
 - Related task breakdown or checklist artifacts from the selected adapter workflow
 
@@ -57,7 +57,7 @@ Review any available:
 
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in `plan.md` (or `proposal.md`) or `tasks.md`.
+1. Identify the approved architecture changes that should be reflected in the technical design or task artifacts.
 2. Preserve the feature intent and implementation scope.
 3. Add or refine task entries for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.

--- a/orchestration/apply.md
+++ b/orchestration/apply.md
@@ -28,14 +28,14 @@ You may update plan and task artifacts, but you must keep the changes small, tar
 
 ## Allowed Edits
 
-You may revise:
-
-- the technical design artifact
+You may revise directly:
+- the technical design artifact (`plan.md` / `design.md`)
 - `tasks.md`
 - Related task breakdown or checklist artifacts from the selected adapter workflow
 
-You should not:
+For findings targeting upstream artifacts (`proposal.md`, `spec.md`), `ag-apply` acts as an orchestrator and delegates those fixes to the SDD tool's native update capability (or runs an inline AG-native fallback) upon user confirmation. `ag-apply` does NOT edit upstream artifacts directly.
 
+You should not:
 - Rewrite the whole plan unnecessarily.
 - Remove product intent or feature scope.
 - Introduce SDD-tool-specific rules into the core workflow.
@@ -44,8 +44,7 @@ You should not:
 ## Inputs To Consider
 
 Review any available:
-
-- Existing architecture review output.
+- Existing architecture review output (including `Target:` fields for finding classification).
 - Approved refactor tasks.
 - Constitution rules.
 - Feature specification.
@@ -55,18 +54,39 @@ Review any available:
 - Optional preset guidance, if available.
 - Approved Constitution Update Proposals, if present.
 
+## Finding Partitioning
+
+Before executing edits, `ag-apply` partitions all review findings into two distinct groups based on their `Target:` field:
+
+1. **Plan/Tasks Group**: Findings targeting the adapter-resolved planning artifact (`plan.md` for SpecKit, `design.md` for OpenSpec/generic projects that use that name) or `tasks.md`.
+2. **Upstream Group**: Findings targeting `proposal.md` or `spec.md`.
+
+For multi-artifact findings, resolution is performed in authoritative order (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`), fixing the authoritative artifact first and propagating downstream.
+
 ## Apply Procedure
 
-1. Identify the approved architecture changes that should be reflected in the technical design or task artifacts.
-2. Preserve the feature intent and implementation scope.
-3. Add or refine task entries for refactors that are safe to schedule.
+### Step 1: Direct Apply for Plan/Tasks Group
+1. Process all findings in the **Plan/Tasks Group** directly.
+2. Preserve feature intent and implementation scope.
+3. Add or refine task entries in `tasks.md` for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.
-5. Update plan language so boundaries, contracts, and ownership are explicit.
+5. Update plan/design language so boundaries, contracts, and ownership are explicit.
 6. Keep implementation moving unless the Constitution explicitly says the issue is blocking.
-7. If a refactor is too large for the current scope, create a scoped task rather than expanding the whole plan.
+7. If a refactor is too large for current scope, create a scoped task rather than expanding the whole plan.
 8. If an approved Constitution Update Proposal exists, reflect it as explicit follow-up work without auto-changing the Constitution itself.
-9. If the surrounding workflow emits a token-savings banner, leave it visible while applying the approved changes.
-10. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
+9. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
+
+### Step 2: Confirmation for Upstream Group
+If the **Upstream Group** contains findings:
+1. Present a grouped summary table of upstream findings organized by target artifact (`proposal.md`, `spec.md`).
+2. Prompt the user for confirmation: `"Proceed with upstream artifact fixes? [Y/n]"`
+3. If the user declines/rejects, mark all upstream findings as `skipped` in the final report and exit early.
+
+### Step 3: Upstream Delegation / Fallback Execution
+Upon user confirmation for the **Upstream Group**:
+1. **Native Delegation**: If the active SDD tool exposes a native update capability (e.g. `openspec-update-change` in OpenSpec), delegate the upstream findings to that capability with finding details as input context.
+2. **AG-Native Fallback**: If the active SDD tool lacks a native update capability (e.g. generic mode), execute an inline AG-native artifact-fix following the exact same confirmation and authoritative-first ordering.
+3. **Propagation**: Ensure fixes are applied in authoritative order (`spec.md` first, then the adapter-resolved planning artifact, then `tasks.md` for coherence).
 
 ## Write-Back Rules
 
@@ -78,7 +98,27 @@ Review any available:
 
 ## Output Format
 
-Return the changed artifact summary and updated planning content in the selected adapter's artifact format.
+Return a unified summary report covering both direct edits and delegated upstream fixes:
+
+```markdown
+# Architecture Apply Summary
+
+## Direct Edits (Plan / Tasks)
+- **Status**: [Applied / Skipped / None Needed]
+- **Modified Artifacts**: [e.g. design.md, tasks.md]
+- **Applied Findings**: [List of applied plan/tasks findings]
+
+## Delegated Upstream Edits (Proposal / Spec)
+- **Status**: [Applied / Delegated / Skipped by User / No Upstream Findings]
+- **Delegation Target**: [Native capability name or AG-Native Fallback]
+- **Upstream Findings**:
+  | ID | Target | Finding | Status |
+  |:---|:---|:---|:---|
+  | V1 | `spec.md` | ... | Applied / Skipped |
+
+## Next Step
+- [e.g. Continue to implementation or run verification]
+```
 
 ## Backward Compatibility
 

--- a/orchestration/governed-delivery-team.md
+++ b/orchestration/governed-delivery-team.md
@@ -90,7 +90,7 @@ Before engineering planning begins, generate a business-oriented User Story repr
 
 ## Phase 4 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 

--- a/orchestration/governed-delivery-team.md
+++ b/orchestration/governed-delivery-team.md
@@ -90,11 +90,11 @@ Before engineering planning begins, generate a business-oriented User Story repr
 
 ## Phase 4 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, the technical design artifact, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: `plan.md` (or `proposal.md`) does not exist or is empty.
+- `missing`: the technical design artifact does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 finding, policy-designated blocking security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
@@ -118,7 +118,7 @@ Before technical planning can occur, the feature must be formally proposed and s
 ## Phase 5 — Plan Gate
 
 If the plan is `missing` or `stale`, run `ag-governed-plan` with the active feature context.
-- **Linkage metadata**: When generating the new technical plan (`plan.md`, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
+- **Linkage metadata**: When generating the new technical plan (the technical design artifact, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
 If the plan is `review-required`, reuse it and run the applicable security plan review plus the adapter-registered violation-detection capability. Do not regenerate a plan merely because review is needed.
 

--- a/orchestration/governed-delivery-team.md
+++ b/orchestration/governed-delivery-team.md
@@ -90,11 +90,11 @@ Before engineering planning begins, generate a business-oriented User Story repr
 
 ## Phase 4 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: `plan.md` does not exist or is empty.
+- `missing`: `plan.md` (or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 finding, policy-designated blocking security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
@@ -118,7 +118,7 @@ Before technical planning can occur, the feature must be formally proposed and s
 ## Phase 5 — Plan Gate
 
 If the plan is `missing` or `stale`, run `ag-governed-plan` with the active feature context.
-- **Linkage metadata**: When generating the new technical plan (`plan.md` or `design.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
+- **Linkage metadata**: When generating the new technical plan (`plan.md`, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
 If the plan is `review-required`, reuse it and run the applicable security plan review plus the adapter-registered violation-detection capability. Do not regenerate a plan merely because review is needed.
 

--- a/orchestration/governed-delivery.md
+++ b/orchestration/governed-delivery.md
@@ -65,7 +65,7 @@ Prefer summaries, metadata, tags, confidence, and related files. Load full entri
 
 ## Phase 3 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 

--- a/orchestration/governed-delivery.md
+++ b/orchestration/governed-delivery.md
@@ -65,11 +65,11 @@ Prefer summaries, metadata, tags, confidence, and related files. Load full entri
 
 ## Phase 3 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, the technical design artifact, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: `plan.md` (or `proposal.md`) does not exist or is empty.
+- `missing`: the technical design artifact does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 finding, policy-designated blocking security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.

--- a/orchestration/governed-delivery.md
+++ b/orchestration/governed-delivery.md
@@ -65,11 +65,11 @@ Prefer summaries, metadata, tags, confidence, and related files. Load full entri
 
 ## Phase 3 — Inspect Resume State
 
-Inspect `spec.md`, `plan.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
+Inspect `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `security-constraints.md`, and available architecture review artifacts for the active feature.
 
 Classify the plan:
 
-- `missing`: `plan.md` does not exist or is empty.
+- `missing`: `plan.md` (or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
 - `blocked`: an unresolved P0 finding, policy-designated blocking security finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.

--- a/orchestration/governed-plan.md
+++ b/orchestration/governed-plan.md
@@ -105,7 +105,7 @@ Run:
 ```
 
 Inputs to consider:
-- The generated `plan.md`.
+- The generated `plan.md` (or `proposal.md`).
 - `{adapter_path:arch-constitution}`.
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).

--- a/orchestration/governed-plan.md
+++ b/orchestration/governed-plan.md
@@ -105,7 +105,7 @@ Run:
 ```
 
 Inputs to consider:
-- The generated `plan.md` (or `proposal.md`).
+- The generated the technical design artifact.
 - `{adapter_path:arch-constitution}`.
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (the exact filenames depend on the active SDD tool) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (the exact filenames depend on the active SDD tool)
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
@@ -144,7 +144,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
 **Absence Evidence** is acceptable for CRITICAL violations only. Example:
-- "Constitution requires data access abstraction but `plan.md` (or `proposal.md`) does not specify one"
+- "Constitution requires data access abstraction but the technical design artifact does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
 

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -49,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Artifact Scope**:
-   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`) against the architectural rules and constitutions.
+   - Focus strictly on validating the specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`) against the architectural rules and constitutions.
    - Do **NOT** run changed-files detection scripts or evaluate source code.
 
 ## Input & Context Loading
@@ -70,7 +70,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Planning Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
@@ -144,7 +144,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
 **Absence Evidence** is acceptable for CRITICAL violations only. Example:
-- "Constitution requires data access abstraction but `plan.md` does not specify one"
+- "Constitution requires data access abstraction but `plan.md` (or `proposal.md`) does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
 

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -127,13 +127,14 @@ Detect violations such as:
 2. **Model Context**: Build Semantic Models for the identified scope.
 3. **Analyze Alignment**: Compare the initial specification intent vs. the proposed architectural design. Ensure the proposed design or plan accurately satisfies the spec without violating constraints.
 4. **Scan Principles**: Apply Review Principles across the planned boundaries.
-5. **Security & Governance Cross-Check**:
+5. **Target Classification**: Determine which artifact each finding targets based on the finding's source evidence. Emit the adapter-resolved filename: `plan.md` for SpecKit planning artifacts, `design.md` for OpenSpec design artifacts, and the applicable `proposal.md`, `spec.md`, or `tasks.md` otherwise. For multi-artifact findings, set `Target:` to the authoritative artifact (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`).
+6. **Security & Governance Cross-Check**:
   - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
   - Cross-reference architecture decisions with security trust boundaries.
-6. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
-7. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
-8. **Repository Hygiene Scan**: Evaluate the planning structure against hygiene rules loaded from `{adapter_path:hygiene-rules}`.
-9. **Generate Refactors**: Produce structured tasks for each confirmed violation in the plan.
+7. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
+8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
+9. **Repository Hygiene Scan**: Evaluate the planning structure against hygiene rules loaded from `{adapter_path:hygiene-rules}`.
+10. **Generate Refactors**: Produce structured tasks for each confirmed violation in the plan.
 
 ---
 
@@ -144,7 +145,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
 **Absence Evidence** is acceptable for CRITICAL violations only. Example:
-- "Constitution requires data access abstraction but the technical design artifact does not specify one"
+- "Constitution requires data access abstraction but `{adapter_path:plan}` does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
 
@@ -163,9 +164,9 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `{adapter_path:arch-constitution}` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
+| ID | Category | Severity | Location(s) | Target | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | `{adapter_path:arch-constitution}` | `{adapter_path:plan}` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
 
 ### Task Synchronization
 - **Status**: [Synced / Drifted]
@@ -217,7 +218,7 @@ Findings categorized by severity based on the active hygiene rules.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
 4. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
-5. **Next Step**: [e.g. Run `/speckit.security-review.plan` for security-first findings, or `/ag-apply` for architecture fixes]
+5. **Next Step**: Run `/ag-apply` to resolve all findings (plan/tasks findings will be applied directly; upstream findings in `proposal.md` or `spec.md` will be delegated with confirmation).
 6. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 
 ## Framework Preset Guidance

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -10,7 +10,7 @@ Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -100,7 +100,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 4. **Implementation Context**:
-    - Active specification and planning artifacts (e.g., `spec.md`, `design.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`)
+    - Active specification and planning artifacts (the exact filenames depend on the active SDD tool)
     - The detected `changed_files` and their respective directories.
 
 5. **Repository Hygiene**:

--- a/orchestration/verify.md
+++ b/orchestration/verify.md
@@ -47,7 +47,7 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 Build internal representations:
 - **Task-Boundary Map**: Associate each task with its intended architecture layer (Entry, Application, Domain, Data, External).
 - **Implementation Evidence**: For each completed task (`[x]`), scan referenced files for logic that addresses the task description.
-- **Contract Inventory**: Extract planned API/Data signatures from `plan.md`.
+- **Contract Inventory**: Extract planned API/Data signatures from the technical design artifact.
 - **Duplication Check**: Look for repeated business logic, validation, or transformation across files and confirm it has been centralized or explicitly justified.
 
 **Common DRY Signals**

--- a/orchestration/verify.md
+++ b/orchestration/verify.md
@@ -89,10 +89,10 @@ Build internal representations:
 
 ## Verification Report
 
-| ID | Category | Severity | Location(s) | Summary | Recommendation |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
-| V2 | Boundary | HIGH | `ctrl/user.ts` | Database query found in Controller layer | Move query to Repository/Data layer |
+| ID | Category | Severity | Location(s) | Target | Summary | Recommendation |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
+| V2 | Boundary | HIGH | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
 
 ### Task Status Analysis
 For each task in `tasks.md`:

--- a/orchestration/violation-detection.md
+++ b/orchestration/violation-detection.md
@@ -67,7 +67,7 @@ Before analysis, build internal representations (do not output these):
 ## Detection Scope
 
 ### A. Intent & Alignment
-- **Intent Divergence**: Implementation deviates fundamentally from `spec.md` or `plan.md` intent.
+- **Intent Divergence**: Implementation deviates fundamentally from `spec.md` or the technical design artifact intent.
 - **Hallucinated Abstractions**: Plan mentions an abstraction (e.g., Repository) that is missing in code.
 - **Spec-Code Mismatch**: Functional requirements from spec are implemented in the wrong architectural layer.
 - **Ponytail Violation (Bloat)**: Plan, tasks, or code duplicate existing capability, add avoidable files or dependencies, include unnecessary boilerplate or future-proofing, or bypass a correct standard-library or native-platform feature.
@@ -127,7 +127,7 @@ A Security-Architecture Conflict occurs when security requirements and architect
 
     If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 2. **Verify Evidence**: Check if task-referenced files exist and contain expected implementation logic.
-3. **Analyze Alignment**: Compare `spec.md` intent vs. `plan.md` architecture vs. actual behavior.
+3. **Analyze Alignment**: Compare `spec.md` intent vs. the technical design artifact architecture vs. actual behavior.
 4. **Scan Principles**: Apply detection scope across boundaries and contracts.
 5. **Security & Governance Cross-Check**: Ensure architecture decisions do not violate `{adapter_path:security-constitution}` or `{adapter_path:security-constraints}`.
 6. **Assign Severity**:

--- a/orchestration/workflow.md
+++ b/orchestration/workflow.md
@@ -78,7 +78,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `{adapter_path:security-constraints}`
-   - `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`
+   - `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/orchestration/workflow.md
+++ b/orchestration/workflow.md
@@ -78,7 +78,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `{adapter_path:security-constraints}`
-   - `spec.md`, `plan.md` (or `proposal.md`), `tasks.md`, `data-model.md`
+   - `spec.md`, the technical design artifact, `tasks.md`, `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/orchestration/workflow.md
+++ b/orchestration/workflow.md
@@ -78,7 +78,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 3. **Feature-Specific Context**:
    - `{adapter_path:security-constraints}`
-   - `spec.md`, `plan.md`, `tasks.md`, `data-model.md`
+   - `spec.md`, `plan.md`, `proposal.md`, `tasks.md`, `data-model.md`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.


### PR DESCRIPTION
Addresses a missing reference to the OpenSpec `proposal.md` artifact in `ag-review-artifacts` and several other governed commands that only listed `plan.md` or `design.md`.