### PR TITLE
fix: preserve and harden SpecKit archive behavior

### DIFF
--- a/adapters/spec-kit.md
+++ b/adapters/spec-kit.md
@@ -34,8 +34,8 @@ Use this adapter when the active SDD tool is **Spec Kit** (`.specify/` directory
 
 | Canonical Key | SpecKit Invocation or Fallback |
 |---|---|
-| create-spec | `/speckit.specify`; if unavailable, create `{adapter_path:spec}` inline from user intent and governing context |
-| create-change | Require or create the feature workspace before specification creation |
+| create-spec | `/speckit.specify`; if unavailable, create `{adapter_path:spec}` inline from user intent and governing context, enforcing SpecKit numbering rules (`NNN-<short-name>`) and updating `.specify/feature.json` |
+| create-change | Require or create the feature workspace following `.specify/init-options.json` numbering conventions before specification creation, and maintain `.specify/feature.json` |
 | archive | SpecKit has no native archive command; after verification, move active feature artifacts to the configured archive location only with explicit user approval |
 | verify | Use the registered Architecture Guard verification capability, or run the verification workflow inline |
 | clarify-spec | `/speckit.clarify`; if unavailable, ask and apply an inline ambiguity-resolution loop |
@@ -54,6 +54,22 @@ Use this adapter when the active SDD tool is **Spec Kit** (`.specify/` directory
 | architecture-review | Use the registered architecture-review capability or review the resolved artifacts inline |
 | refactor-generator | Use the registered refactor-generator capability or generate refactor tasks inline |
 | violation-detection | Use the registered violation-detection capability or detect drift inline |
+
+## Feature Directory & State Management
+
+SpecKit enforces explicit directory naming and state persistence rules:
+1. **Directory Numbering Resolution**:
+   - Check `.specify/init-options.json` for `feature_numbering`.
+   - If `"sequential"` or absent: directory name MUST be `specs/NNN-<short-name>` (where `NNN` is the next available 3-digit number after scanning `specs/`, e.g. `specs/001-safe-dashboard-users-invoices`).
+   - If `"timestamp"`: directory name MUST be `specs/YYYYMMDD-HHMMSS-<short-name>`.
+2. **State Tracking File (`.specify/feature.json`)**:
+   - When a feature is selected or created, persist the resolved directory path:
+     ```json
+     {
+       "feature_directory": "specs/001-feature-name"
+     }
+     ```
+   - Downstream commands (`create-plan`, `create-tasks`, `implement`, `analyze`) read `.specify/feature.json` first to identify the active feature directory.
 
 ## Constitution Layout
 

--- a/archive.test.ts
+++ b/archive.test.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { runArchive } from './cli/archive.js';
 
-test('archive command completely removes source directory including empty nested dirs', () => {
+test('archive command completely removes source directory including empty nested dirs', async () => {
     const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-archive-test-'));
     
     // Mock process.cwd() for the test
@@ -26,7 +26,7 @@ test('archive command completely removes source directory including empty nested
         fs.mkdirSync(unrelatedDir, { recursive: true });
         
         // Run archive
-        runArchive(changeName);
+        await runArchive(changeName);
         
         // Verify target exists
         const date = new Date().toISOString().split('T')[0];
@@ -42,6 +42,95 @@ test('archive command completely removes source directory including empty nested
         assert.ok(fs.existsSync(unrelatedDir), 'Unrelated directories should not be deleted');
     } finally {
         // Restore cwd and cleanup
+        process.cwd = originalCwd;
+        fs.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});
+
+test('SpecKit archive retains the feature and updates system_context idempotently', async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-speckit-archive-test-'));
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+
+    try {
+        const featureRoot = path.join(tmpdir, 'specs', '001-feature');
+        fs.mkdirSync(featureRoot, { recursive: true });
+        fs.mkdirSync(path.join(tmpdir, '.specify'), { recursive: true });
+        fs.writeFileSync(path.join(tmpdir, '.specify', 'feature.json'), JSON.stringify({ feature_directory: 'specs/001-feature' }));
+        fs.writeFileSync(path.join(featureRoot, 'spec.md'), '# Feature\n\n## Purpose\nAdds the feature.\n');
+
+        await runArchive('ignored-name');
+        await runArchive('ignored-name');
+
+        const index = fs.readFileSync(path.join(tmpdir, 'specs', 'system_context.md'), 'utf8');
+        assert.ok(fs.existsSync(path.join(featureRoot, 'spec.md')));
+        assert.strictEqual((index.match(/architecture-guard:feature=/g) ?? []).length, 1);
+        assert.match(index, /Feature spec: \[specs\/001-feature\/spec\.md\]/);
+    } finally {
+        process.cwd = originalCwd;
+        fs.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});
+
+test('SpecKit archive warns without removing the feature when the context index cannot be written', async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-speckit-archive-warning-test-'));
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+
+    try {
+        const featureRoot = path.join(tmpdir, 'specs', '001-feature');
+        fs.mkdirSync(featureRoot, { recursive: true });
+        fs.mkdirSync(path.join(tmpdir, '.specify'), { recursive: true });
+        fs.mkdirSync(path.join(tmpdir, 'specs', 'system_context.md'), { recursive: true });
+        fs.writeFileSync(path.join(featureRoot, 'spec.md'), '# Feature\n');
+
+        await runArchive('001-feature');
+
+        assert.ok(fs.existsSync(path.join(featureRoot, 'spec.md')));
+    } finally {
+        process.cwd = originalCwd;
+        fs.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});
+
+test('SpecKit archive rejects traversal metadata and ambiguous framework markers', async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-archive-validation-test-'));
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+
+    try {
+        fs.mkdirSync(path.join(tmpdir, '.specify'), { recursive: true });
+        fs.writeFileSync(path.join(tmpdir, '.specify', 'feature.json'), JSON.stringify({ feature_directory: '../outside' }));
+        await assert.rejects(() => runArchive('feature'), /must resolve under the project root/);
+
+        fs.mkdirSync(path.join(tmpdir, 'openspec'), { recursive: true });
+        fs.writeFileSync(path.join(tmpdir, 'openspec', 'config.yaml'), 'schema: spec-driven');
+        await assert.rejects(() => runArchive('feature'), /both SpecKit and OpenSpec markers/);
+
+        fs.mkdirSync(path.join(tmpdir, 'openspec', 'changes', 'explicit'), { recursive: true });
+        await runArchive('explicit', { framework: 'openspec' });
+    } finally {
+        process.cwd = originalCwd;
+        fs.rmSync(tmpdir, { recursive: true, force: true });
+    }
+});
+
+test('archive command supports JSON success output', async () => {
+    const tmpdir = fs.mkdtempSync(path.join(os.tmpdir(), 'ag-archive-json-test-'));
+    const originalCwd = process.cwd;
+    process.cwd = () => tmpdir;
+
+    try {
+        const sourceDir = path.join(tmpdir, 'openspec', 'changes', 'json-change');
+        fs.mkdirSync(sourceDir, { recursive: true });
+        const result = await runArchive('json-change', { json: true });
+        assert.deepStrictEqual(result, {
+            status: 'success',
+            framework: 'openspec',
+            changeName: 'json-change',
+            targetDir: path.join(tmpdir, 'openspec', 'changes', 'archive', `${new Date().toISOString().split('T')[0]}-json-change`)
+        });
+    } finally {
         process.cwd = originalCwd;
         fs.rmSync(tmpdir, { recursive: true, force: true });
     }

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -70,8 +70,10 @@ program
 
 program
   .command('archive <changeName>')
-  .description('Archive a completed OpenSpec change')
-  .action(runArchive);
+  .description('Finalize or archive a completed SDD feature')
+  .option('--json', 'Output a machine-readable result')
+  .option('--framework <framework>', 'Override detection: speckit | openspec')
+  .action(async (changeName, options) => { await runArchive(changeName, options); });
 
 import { runSelfUpdate } from '../cli/self-update';
 

--- a/cli/archive.ts
+++ b/cli/archive.ts
@@ -1,35 +1,107 @@
-import fs from 'node:fs';
+import { access, cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
+import { z } from 'zod';
 
-export function runArchive(changeName: string) {
-    if (!changeName) {
-        console.error('Error: change name is required');
-        process.exit(1);
+const featureStateSchema = z.object({ feature_directory: z.string().min(1) });
+const frameworkSchema = z.enum(['speckit', 'openspec']);
+type ArchiveOptions = { json?: boolean; framework?: string };
+
+async function exists(target: string) {
+    try {
+        await access(target);
+        return true;
+    } catch {
+        return false;
     }
+}
 
-    const changesDir = path.join(process.cwd(), 'openspec', 'changes');
+function reportError(message: string): never {
+    process.stderr.write(`Error: ${message}\n`);
+    throw new Error(message);
+}
+
+function reportWarning(message: string) {
+    process.stderr.write(`Warning: ${message}\n`);
+}
+
+export async function runArchive(changeName: string, options: ArchiveOptions = {}) {
+    if (!changeName) reportError('change name is required');
+
+    const root = process.cwd();
+    const framework = await resolveFramework(root, options.framework);
+    if (framework === 'speckit') return finalizeSpecKitFeature(changeName, root, options.json === true);
+    return archiveOpenSpecChange(changeName, root, options.json === true);
+}
+
+async function resolveFramework(root: string, override?: string) {
+    if (override) return frameworkSchema.parse(override);
+    const hasSpecKit = await exists(path.join(root, '.specify'));
+    const hasOpenSpec = await exists(path.join(root, 'openspec', 'config.yaml'));
+    if (hasSpecKit && hasOpenSpec) reportError('both SpecKit and OpenSpec markers are present; select an adapter explicitly');
+    return hasSpecKit ? 'speckit' : 'openspec';
+}
+
+async function archiveOpenSpecChange(changeName: string, root: string, json: boolean) {
+    const changesDir = path.join(root, 'openspec', 'changes');
     const sourceDir = path.join(changesDir, changeName);
-    
-    if (!fs.existsSync(sourceDir)) {
-        console.error(`Error: source change directory not found: ${sourceDir}`);
-        process.exit(1);
-    }
-    
+    if (!await exists(sourceDir)) reportError(`source change directory not found: ${sourceDir}`);
+
     const date = new Date().toISOString().split('T')[0];
-    const targetName = changeName.match(/^\d{4}-\d{2}-\d{2}-/) ? changeName : `${date}-${changeName}`;
+    const targetName = /^\d{4}-\d{2}-\d{2}-/.test(changeName) ? changeName : `${date}-${changeName}`;
     const archiveDir = path.join(changesDir, 'archive');
     const targetDir = path.join(archiveDir, targetName);
-    
-    if (fs.existsSync(targetDir)) {
-        console.error(`Error: destination already exists: ${targetDir}`);
-        process.exit(1);
+    if (await exists(targetDir)) reportError(`destination already exists: ${targetDir}`);
+
+    await mkdir(archiveDir, { recursive: true });
+    await cp(sourceDir, targetDir, { recursive: true });
+    await rm(sourceDir, { recursive: true, force: true });
+    const result = { status: 'success', framework: 'openspec', changeName, targetDir } as const;
+    process.stdout.write(json ? `${JSON.stringify(result)}\n` : `Successfully archived ${changeName} to ${targetDir}\n`);
+    return result;
+}
+
+async function finalizeSpecKitFeature(changeName: string, root: string, json: boolean) {
+    let featureDirectory = path.join('specs', changeName);
+    const featureJson = path.join(root, '.specify', 'feature.json');
+
+    if (await exists(featureJson)) {
+        const rawState = JSON.parse(await readFile(featureJson, 'utf8'));
+        const state = featureStateSchema.parse(rawState);
+        featureDirectory = state.feature_directory;
     }
-    
-    fs.mkdirSync(archiveDir, { recursive: true });
-    
-    // Perform copy and explicit empty directory cleanup
-    fs.cpSync(sourceDir, targetDir, { recursive: true });
-    fs.rmSync(sourceDir, { recursive: true, force: true });
-    
-    console.log(`Successfully archived ${changeName} to ${targetDir}`);
+
+    const featureRoot = path.resolve(root, featureDirectory);
+    const relativeFeature = path.relative(root, featureRoot);
+    if (!relativeFeature || relativeFeature.startsWith('..') || path.isAbsolute(relativeFeature)) {
+        reportError('SpecKit feature_directory must resolve under the project root');
+    }
+
+    const specPath = path.join(featureRoot, 'spec.md');
+    if (!await exists(specPath)) reportWarning(`SpecKit feature spec not found: ${specPath}`);
+    if (!await exists(specPath)) return;
+
+    const normalizedFeature = relativeFeature.split(path.sep).join('/');
+    const indexPath = path.join(root, 'specs', 'system_context.md');
+    const specText = await readFile(specPath, 'utf8');
+    const title = specText.match(/^#\s+(.+)$/m)?.[1] ?? path.basename(featureRoot);
+    const purpose = specText.match(/^## Purpose\s*\n+([\s\S]*?)(?=^## |$)/m)?.[1].trim().replace(/\s+/g, ' ') ?? 'Completed SpecKit feature.';
+    const marker = `<!-- architecture-guard:feature=${normalizedFeature} -->`;
+    const entry = `${marker}\n## ${title}\n${purpose}\n\n- Feature spec: [${normalizedFeature}/spec.md](${normalizedFeature}/spec.md)\n`;
+
+    try {
+        await mkdir(path.dirname(indexPath), { recursive: true });
+        const current = await exists(indexPath) ? await readFile(indexPath, 'utf8') : '# System Context\n\n';
+        const markerStart = current.indexOf(marker);
+        const nextHeading = markerStart >= 0 ? current.indexOf('\n<!-- architecture-guard:feature=', markerStart + marker.length) : -1;
+        const replacementEnd = markerStart >= 0 ? (nextHeading >= 0 ? nextHeading + 1 : current.length) : current.length;
+        const updated = markerStart >= 0
+            ? current.slice(0, markerStart) + entry + current.slice(replacementEnd)
+            : `${current.trimEnd()}\n\n${entry}`;
+        await writeFile(indexPath, `${updated.trimEnd()}\n`);
+        const result = { status: 'success', framework: 'speckit', featureDirectory: normalizedFeature, indexPath } as const;
+        process.stdout.write(json ? `${JSON.stringify(result)}\n` : `Finalized SpecKit feature ${normalizedFeature}\n`);
+        return result;
+    } catch {
+        reportWarning(`unable to update SpecKit context index: ${indexPath}`);
+    }
 }

--- a/commands/governed-archive.md
+++ b/commands/governed-archive.md
@@ -22,7 +22,7 @@ Verifies, then finalizes a completed feature. Changelog, memory, Git, and worksp
 - Determine the active framework via `adapters/detect.md`.
 - **All frameworks**: Use the loaded adapter's `verify` mapping first and stop if verification fails or has unresolved blocking findings.
 - **If OpenSpec**: After verification and explicit approval, use the adapter's `archive` mapping; ask for the change name if it is ambiguous.
-- **If SpecKit**: After verification and explicit approval, ask for the archive destination and move the active feature artifacts there; then use the adapter's `consolidate-specs` mapping to refresh the fallback index.
+- **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in their native `specs/<feature>/` directory and incrementally update `specs/system_context.md`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
 - **If Generic**: Use the adapter's inline verification fallback. Explain that there is no native archive command, ask for an archive destination, and move artifacts only after explicit approval.
 
 ### Step 2 — Automated Changelog Update

--- a/commands/governed-delivery.md
+++ b/commands/governed-delivery.md
@@ -40,8 +40,8 @@ Before creating, planning, or modifying any active change:
 
 ## Phase 1 — Detect the Active Feature and Integrations
 
-1. Resolve the active feature from the user's explicit path, Spec Kit feature metadata, current branch, or a single unambiguous directory under `specs/`, in that order.
-2. If no active feature directories exist (ignoring archives), automatically derive a kebab-case name from the user's goal and create the new feature directory using the active SDD tool's workflow.
+1. Resolve the active feature from the user's explicit path, `.specify/feature.json` (for SpecKit), Spec Kit feature metadata, current branch, or a single unambiguous directory under `specs/`, in that order.
+2. If no active feature directories or specifications exist (ignoring archives), run the adapter-registered `governed-spec` capability (or `/speckit.specify`) to properly initialize the feature workspace and specification following native SDD tool numbering rules.
 3. Do not guess when multiple feature directories are plausible. Ask the user to identify the feature.
 4. Detect `flash-mem` as an MCP service. Do not look for it in `.specify/extensions.yml`.
 5. Detect Security Review from `.specify/extensions.yml`. Accept `security-review` as the canonical extension id and `spec-kit-security-review` as a compatibility alias.

--- a/orchestration/governed-archive.md
+++ b/orchestration/governed-archive.md
@@ -22,7 +22,7 @@ Verifies, then finalizes a completed feature. Changelog, memory, Git, and worksp
 - Determine the active framework via `adapters/detect.md`.
 - **All frameworks**: Trigger `{adapter_command:verify}` first and stop if verification fails or has unresolved blocking findings.
 - **If OpenSpec**: After verification and explicit approval, trigger `{adapter_command:archive}`; ask for the change name and archive destination if either is ambiguous.
-- **If SpecKit**: After verification and explicit approval, ask for the archive destination and move the active feature artifacts there, then trigger `{adapter_command:consolidate-specs}`.
+- **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in their native `specs/<feature>/` directory and incrementally update `specs/system_context.md`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
 
 ### Step 2 — Automated Changelog Update
 Parse the archived feature purpose and requirements into a proposed changelog entry. Ask for explicit approval before appending it to CHANGELOG.md or RELEASE_NOTES.md; if neither file exists, report that and do not create one silently.


### PR DESCRIPTION
## Summary
- Preserve SpecKit feature directories and incrementally update `system_context.md`.
- Harden archive routing with async filesystem operations, validated feature metadata, path containment, and dual-marker protection.
- Add framework-neutral CLI help, explicit framework overrides, JSON output, and focused archive tests.
- Update governed archive and delivery guidance to match native SpecKit behavior.

## Verification
- `npm test`
- `npm run lint`
- `openspec validate "speckit-native-alignment" --strict`
- `git diff --check`

## Security
- Validates `.specify/feature.json` with Zod.
- Rejects feature paths outside the project root.
- Rejects ambiguous SpecKit/OpenSpec marker combinations unless explicitly overridden.