### PR TITLE
fix: align SDD orchestration and legacy skills

### DIFF
--- a/ADAPTERS.md
+++ b/ADAPTERS.md
@@ -8,7 +8,7 @@ Adapters are the bridge between Architecture Guard's tool-agnostic governance co
 Orchestration command (e.g., init.md)
          │
          ▼
-  adapters/detect.md  ─── detects active SDD tool
+  adapters/resolve.md  ─── resolves the selected SDD adapter
          │
          ▼
   adapters/{tool}.md  ─── provides path map + command map + gaps
@@ -75,8 +75,8 @@ When governance checks should run in relation to the SDD tool's lifecycle.
 3. Replace the Command Map with your tool's CLI commands or agent commands.
 4. Declare any gaps your tool has.
 5. Place the file at `adapters/{tool-name}.md`.
-6. Update `adapters/detect.md` detection chain to recognize your tool's marker.
+6. Update `adapters/resolve.md` fallback markers to recognize your tool.
 
 Adapter files are self-contained markdown. No code changes needed.
 
-Installed shared resources always resolve under `.architecture-guard/{templates,presets,hygiene-rules,sonar-rules,scripts}`. SDD tool directories hold SDD artifacts only. Before a command body runs, detection resolves every adapter token; missing keys stop with `AdapterMissingKey: <kind>:<key>` and unresolved substitutions stop with `AdapterUnresolvedToken: <token>`.
+Installed shared resources always resolve under `.architecture-guard/{templates,presets,hygiene-rules,sonar-rules,scripts}`. SDD tool directories hold SDD artifacts only. Before a command body runs, the resolution preamble resolves every adapter token; missing keys stop with `AdapterMissingKey: <kind>:<key>` and unresolved substitutions stop with `AdapterUnresolvedToken: <token>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,9 @@ Thank you for your interest in contributing!
 
 ```
 extension.yml          ← Extension manifest
-commands/               ← Spec Kit command definitions (single source of truth)
+orchestration/          ← Canonical cross-SDD command definitions
+commands/               ← Legacy Spec Kit extension command definitions
+adapters/               ← SDD-specific path and command mappings
 scripts/               ← Shell/PowerShell scripts for file detection and maintenance
 presets/               ← Framework-specific architecture presets
 templates/             ← Templates for reports and artifacts
@@ -17,11 +19,20 @@ examples/              ← Example architecture reports
 
 ### Prompt Changes
 
-If you want to modify architecture review rules or detection logic:
+Architecture Guard has two supported delivery channels:
 
-1. Update the relevant file in `commands/`. Each prompt file is self-contained with its full rules, steps, and output format.
-2. Run `npm run test` or `npx architecture-guard test-install` to verify consistency.
-3. If you add a new command, register it in `extension.yml` under `provides.commands`.
+- `orchestration/` is authoritative for standalone installation and all cross-SDD behavior. It must use adapter tokens rather than hard-coded Spec Kit or OpenSpec commands.
+- `commands/` is the self-contained compatibility surface registered by `extension.yml` for the legacy Spec Kit extension. It may use Spec Kit-native paths and commands, but must preserve the same safety, approval, severity, memory, and governance rules as its orchestration counterpart.
+
+The files intentionally are not generated from one another: standalone prompts load adapters at runtime, while legacy extension prompts must remain self-contained.
+
+When modifying a prompt:
+
+1. Make cross-SDD behavior changes in `orchestration/` first.
+2. Apply shared rule or safety changes to the same-name file in `commands/` without copying adapter placeholders into the legacy prompt.
+3. Keep SDD-specific invocation details in `adapters/`; only the legacy command may encode Spec Kit-native details directly.
+4. Run `npm test` to verify both delivery channels remain complete.
+5. If you add a command, add both prompt files and register the legacy file in `extension.yml` under `provides.commands`.
 
 ### Adding Framework Presets
 
@@ -29,8 +40,9 @@ When adding support for a new framework:
 
 1. Create a new preset in `presets/`.
 2. Follow the standard boundary mapping template.
-3. Update `commands/init.md` to include the new framework in the interview flow.
-4. Update `README.md` framework support list.
+3. Update `orchestration/init.md` to include the new framework in the interview flow.
+4. Update `commands/init.md` only when the framework affects the legacy Spec Kit extension experience.
+5. Update `README.md` framework support list.
 
 ### Testing
 
@@ -42,7 +54,9 @@ npm run test
 
 ## Guidelines
 
-- **Self-Contained Prompts**: Every prompt file must carry its full rules, steps, and output format inline. Do not reference external files.
+- **Canonical Orchestration**: Cross-SDD capabilities, adapter contracts, and phase handoffs are defined in `orchestration/`.
+- **Legacy Compatibility**: `commands/` remains self-contained for Spec Kit extension installation and must not weaken canonical safety or governance rules.
+- **Self-Contained Legacy Prompts**: Every file under `commands/` must carry its full rules, steps, and output format inline.
 - **Actionable Findings**: Every violation must include severity, location, evidence, and a suggested fix.
 - **Non-Blocking by Default**: Findings are reported, not enforced. The `refactor-generator` handles task creation.
 - **`flash-mem` Integration**: When project memory exists, use it as context — but never require it. The legacy `memory-hub` name is reference-only.

--- a/OPENSPEC-INTEGRATION.md
+++ b/OPENSPEC-INTEGRATION.md
@@ -38,7 +38,7 @@ Then select:
 ### What Gets Installed
 
 - Command files in your agent's commands/skills directory
-- `adapters/detect.md` and `adapters/openspec.md` in project root
+- `adapters/resolve.md` and `adapters/openspec.md` in project root
 - AGENTS.md governance rules (optional)
 
 ## Key Differences From SpecKit
@@ -61,9 +61,9 @@ OpenSpec does not automatically:
 3. **Verify task-to-code evidence** — After archive, Architecture Guard reads tasks.md checkboxes and validates against code.
 4. **Detect DRY violations** — Architecture Guard scans for duplicated business rules across modules.
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Architecture Guard auto-detects OpenSpec by checking for `openspec/config.yaml`. Detection runs at the start of every orchestration command. Override with `--adapter openspec` if needed.
+Architecture Guard uses `openspec` when `.architecture-guard/selected-adapter` contains `openspec`. The `openspec/config.yaml` marker is only a fallback when no adapter has been persisted. Use `--adapter openspec` for a one-command override.
 
 ## Agent Files
 

--- a/SPECKIT-INTEGRATION.md
+++ b/SPECKIT-INTEGRATION.md
@@ -16,11 +16,11 @@ npx architecture-guard init . --agent opencode --framework spec-kit --commands a
 The installer adds:
 
 - Agent-native governance commands such as `ag-governed-spec`, `ag-review-artifacts`, and `ag-verify`.
-- `adapters/detect.md` and `adapters/spec-kit.md`.
+- `adapters/resolve.md` and `adapters/spec-kit.md`.
 - Runtime resources under `.architecture-guard/`.
 - Optional governance guidance in `AGENTS.md`.
 
-The adapter is selected from the `.specify/` project marker at command time. An installed selection is only advisory and does not override current filesystem detection.
+The adapter selected by `architecture-guard init --framework` is persisted in `.architecture-guard/selected-adapter` and is authoritative at command time. If the project switches SDD tools, rerun init with the new framework or use an explicit `--adapter` override for a single command.
 
 ## Spec Kit Artifact Mapping
 

--- a/adapters/openspec.md
+++ b/adapters/openspec.md
@@ -1,6 +1,6 @@
 # OpenSpec Adapter
 
-Use this adapter when the active SDD tool is **OpenSpec** (`openspec/config.yaml` detected).
+Use this adapter when `.architecture-guard/selected-adapter` is `openspec`. The `openspec/config.yaml` marker is only a fallback for uninitialized projects.
 
 ## Path Map
 
@@ -38,19 +38,19 @@ Use this adapter when the active SDD tool is **OpenSpec** (`openspec/config.yaml
 |---|---|
 | create-spec | Read `openspec instructions specs --change "{change}" --json`, then create the requested change-level specs inline |
 | create-change | If the named change does not exist, run `openspec new change "{change}"`; otherwise reuse it |
-| archive | Run `architecture-guard archive "{change}"` |
+| archive | Run the native `openspec archive "{change}"` command once; do not invoke Architecture Guard archive recursively |
 | verify | Run the Architecture Guard verification workflow against the active change |
 | clarify-spec | Unsupported natively; ask and apply an inline ambiguity-resolution loop |
 | create-plan | Read `openspec instructions design --change "{change}" --json`, then create `{adapter_path:plan}` inline |
 | create-tasks | Read `openspec instructions tasks --change "{change}" --json`, then create `{adapter_path:tasks}` inline |
 | implement | Use the registered OpenSpec apply-change capability; if unavailable, execute unchecked tasks inline and update their status |
 | analyze | Run `openspec validate "{change}"`; supplement it with an inline spec/plan/tasks coverage check |
-| security-review | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-plan | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-tasks | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-branch | Unsupported natively; use the optional Security Review capability or report the skipped review |
+| security-review | Not part of OpenSpec; detect the optional Security Review host capability or report the skipped review |
+| security-review-plan | Not part of OpenSpec; detect the optional Security Review host capability or report the skipped review |
+| security-review-tasks | Not part of OpenSpec; detect the optional Security Review host capability or report the skipped review |
+| security-review-branch | Not part of OpenSpec; detect the optional Security Review host capability or report the skipped review |
 | subagent-synthesize | Unsupported natively; synthesize inline unless the host exposes an equivalent capability |
-| list-specs | `openspec list --specs --json` |
+| list-specs | Run `openspec list --specs --json`, group capability specs by their parent change, and return parent change artifact sets; never treat a capability name as a change identifier |
 | consolidate-specs | Unsupported: use `list-specs` as the fallback index and do not write a consolidated artifact |
 | architecture-apply | Apply plan/tasks findings directly inline; delegate upstream findings (`proposal.md`, `spec.md`) to `openspec-update-change` (or native update capability) with finding details as input context after user confirmation |
 | architecture-review | Use the registered architecture-review capability or review the resolved artifacts inline |

--- a/adapters/resolve.md
+++ b/adapters/resolve.md
@@ -1,21 +1,25 @@
-# SDD Tool Detection
+# SDD Adapter Resolution
 
-This preamble loads before every orchestration command. Its job: detect which SDD tool or workflow the project uses, load the right adapter, and fail gracefully when detection is ambiguous.
+This preamble loads before every orchestration command. Its job is to resolve the adapter selected by CLI initialization, load its mappings, and provide a marker fallback for uninitialized projects.
 
-## Detection Chain
+## Resolution Chain
 
-1. Apply an explicit adapter override (`--adapter spec-kit`, `--adapter openspec`, or `--adapter generic`) before marker detection.
-2. Check for `.specify/` directory in project root → **SpecKit**
+1. Apply an explicit adapter override (`--adapter spec-kit`, `--adapter openspec`, or `--adapter generic`) before persisted selection.
+2. Read `.architecture-guard/selected-adapter` when present. This is the installed project's source of truth and selects the adapter named in the file.
+3. If no persisted selection exists, check for both the `.specify/` directory and `openspec/config.yaml` before making either single-marker choice. If both markers exist, ask the user which adapter to initialize.
+4. If only `.specify/` exists in project root → **SpecKit**
    - Also verify `.specify/memory/` or `.specify/extensions.yml` presence for confidence.
-3. Check for `openspec/config.yaml` in project root → **OpenSpec**
+5. If only `openspec/config.yaml` exists in project root → **OpenSpec**
    - Also verify `openspec/changes/` or `openspec/specs/` for confidence.
-4. If both markers exist, ask the user which adapter to use unless an explicit CLI override was supplied.
-5. Fallback: No SDD tool detected → ask user:
+6. Fallback: No adapter is persisted → ask user:
    ```
-   No SDD tool detected. Which one are you using?
+   No adapter is persisted. Which one are you using?
    1. SpecKit (`.specify/`)
    2. OpenSpec (`openspec/`)
-    3. None (load `adapters/generic.md` and ask for artifact paths as needed)
+   3. None (load `adapters/generic.md` and ask for artifact paths as needed)
+
+   Rerun `architecture-guard init --framework <tool>` to persist a selection,
+   or pass `--adapter <tool>` for this command only.
    ```
 
 ## Load Adapter
@@ -32,12 +36,12 @@ Read `adapters/{tool}.md` → this file contains:
 
 All subsequent path references in the orchestration command use adapter-mapped paths.
 
-## Session Persistence
+## Selection Persistence
 
-The selected SDD tool may be reused within the current AI session, but marker detection runs at the start of every command.
-- A session selection never silently overrides changed filesystem markers. If the markers now identify a different SDD tool, or both markers are present, ask again.
-- A persisted selection file or installer-selected adapter is advisory only and never outranks current markers.
-- If the user explicitly overrides mid-session (`--adapter openspec`), the new adapter is used for subsequent commands.
+The CLI-selected adapter is reused for every command until the user changes it.
+- Filesystem markers do not override `.architecture-guard/selected-adapter`.
+- If the user switches SDD tools, rerun `architecture-guard init` with the new `--framework` value.
+- An explicit `--adapter` override applies only to the current command and does not change the persisted selection.
 
 ## Generic Workflow Mode
 
@@ -56,7 +60,7 @@ Generic workflow mode:
 | Condition | Behavior |
 |---|---|
 | Adapter file missing | Report error: "Adapter file not found at adapters/{tool}.md" |
-| Tool directory exists but empty | Detect as that SDD tool, adapter loads normally |
+| Tool directory exists but empty | Resolve that SDD tool as a marker fallback, then load its adapter |
 | Flash-Mem unavailable | Skip MCP steps, proceed with file-based context |
 | No git repo | Skip branch-related gap fills, continue with remaining steps |
 

--- a/adapters/spec-kit.md
+++ b/adapters/spec-kit.md
@@ -1,6 +1,6 @@
 # SpecKit Adapter
 
-Use this adapter when the active SDD tool is **Spec Kit** (`.specify/` directory detected).
+Use this adapter when `.architecture-guard/selected-adapter` is `spec-kit`. The `.specify/` marker is only a fallback for uninitialized projects.
 
 ## Path Map
 
@@ -36,17 +36,17 @@ Use this adapter when the active SDD tool is **Spec Kit** (`.specify/` directory
 |---|---|
 | create-spec | `/speckit.specify`; if unavailable, create `{adapter_path:spec}` inline from user intent and governing context, enforcing SpecKit numbering rules (`NNN-<short-name>`) and updating `.specify/feature.json` |
 | create-change | Require or create the feature workspace following `.specify/init-options.json` numbering conventions before specification creation, and maintain `.specify/feature.json` |
-| archive | SpecKit has no native archive command; after verification, move active feature artifacts to the configured archive location only with explicit user approval |
+| archive | SpecKit has no native archive command; retain verified feature artifacts in place and incrementally update `{adapter_path:fallback-spec-index}` with explicit user approval |
 | verify | Use the registered Architecture Guard verification capability, or run the verification workflow inline |
 | clarify-spec | `/speckit.clarify`; if unavailable, ask and apply an inline ambiguity-resolution loop |
 | create-plan | `/speckit.plan`; if unavailable, create `{adapter_path:plan}` inline from the active spec |
 | create-tasks | `/speckit.tasks`; if unavailable, create `{adapter_path:tasks}` inline from the active plan |
 | implement | `/speckit.implement`; if unavailable, execute unchecked tasks inline and update their status |
 | analyze | `/speckit.analyze`; if unavailable, compare spec, plan, and tasks inline for coverage and contradictions |
-| security-review | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-plan | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-tasks | Unsupported natively; use the optional Security Review capability or report the skipped review |
-| security-review-branch | Unsupported natively; use the optional Security Review capability or report the skipped review |
+| security-review | Unsupported in standalone SDD orchestration; report `Unavailable`. Current SpecKit extension integration exists only in the legacy `commands/` delivery channel |
+| security-review-plan | Unsupported in standalone SDD orchestration; report `Unavailable`. Current SpecKit extension integration exists only in the legacy `commands/` delivery channel |
+| security-review-tasks | Unsupported in standalone SDD orchestration; report `Unavailable`. Current SpecKit extension integration exists only in the legacy `commands/` delivery channel |
+| security-review-branch | Unsupported in standalone SDD orchestration; report `Unavailable`. Current SpecKit extension integration exists only in the legacy `commands/` delivery channel |
 | subagent-synthesize | `/speckit.subagent.synthesize` when registered; otherwise synthesize inline |
 | list-specs | Enumerate files matching `{adapter_path:spec}` in normalized path order |
 | consolidate-specs | Build `{adapter_path:fallback-spec-index}` inline from `list-specs` results |

--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -34,7 +34,15 @@ program
   .option('--framework <f>', 'spec-kit | openspec | none')
   .option('--commands <list>', 'Comma-separated command names or indices')
   .option('--overwrite <mode>', 'replace | skip | keep-both')
-  .action(runInstallCommand);
+  .action(async (target, options) => {
+    try {
+      await runInstallCommand(target, options);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error("Error: " + message);
+      process.exitCode = 1;
+    }
+  });
 
 program
   .command('detect-changed-files')

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -268,14 +268,9 @@ async function installCommand(agentType: any, commandName: any, cmdDir: any, opt
   const yes = !!opts.yes;
   const overwrite = opts.overwrite;
 
-  // Read from orchestration dir if it exists, fallback to commands dir
-  const orchestrationPath = path.join(ROOT_DIR, 'orchestration', `${commandName}.md`);
-  const commandsPath = path.join(ROOT_DIR, 'commands', `${commandName}.md`);
-  const promptPath = fs.existsSync(orchestrationPath) ? orchestrationPath : commandsPath;
-
+  const promptPath = path.join(ROOT_DIR, 'orchestration', `${commandName}.md`);
   if (!fs.existsSync(promptPath)) {
-    console.error(`  ✗ ${commandName}: prompt file not found`);
-    return;
+    throw new Error(`Canonical orchestration prompt not found: orchestration/${commandName}.md`);
   }
 
   const content = readPrompt(promptPath);
@@ -333,7 +328,7 @@ ${selectedAgents.map(agent => `- \`${path.join(AGENT_CONFIGS[agent].dir, '*')}\`
 
 - **Ponytail Core Contract**: Before spec/plan/tasks/implement, read and apply the ponytail pragmatism contract.
 - **After each phase**: Run architecture review for boundary drift, DRY violations, and repository hygiene.
-- **Framework detection**: Project uses auto-detected SDD framework. Read \`adapters/detect.md\` before first command.
+- **SDD Adapter Resolution**: Project uses the adapter selected during CLI init. Read \`adapters/resolve.md\` before first command.
 `;
 
   if (fs.existsSync(agentsPath)) {
@@ -597,7 +592,7 @@ async function runInit(targetDir, opts) {
   if (fs.existsSync(srcAdaptersDir)) {
     fs.mkdirSync(adaptersDir, { recursive: true });
     const adapter = framework === 'none' ? 'generic' : framework;
-    for (const f of ['detect.md', `${adapter}.md`]) {
+    for (const f of ['resolve.md', `${adapter}.md`]) {
       const src = path.join(srcAdaptersDir, f);
       const dest = path.join(adaptersDir, f);
       if (!fs.existsSync(dest)) {
@@ -618,7 +613,7 @@ async function runInit(targetDir, opts) {
   console.log(`Commands installed: ${selectedCommands.length}`);
   console.log(`Agents: ${selectedAgents.join(', ')}`);
   console.log(`Adapter: adapters/${framework === 'none' ? 'generic' : framework}.md`);
-  console.log(`Detection: adapters/detect.md`);
+  console.log(`Resolution: adapters/resolve.md`);
 }
 
 export async function runInstallCommand(target: any, opts: any) {

--- a/commands/apply.md
+++ b/commands/apply.md
@@ -59,8 +59,13 @@ For multi-artifact findings, resolution is performed in authoritative order (`sp
 
 ## Apply Procedure
 
+### Step 0: Confirm All Writes
+1. Present the exact findings to apply, target artifacts, and proposed write scope.
+2. Prompt the user for explicit confirmation before modifying any file or invoking any write-capable delegated capability.
+3. If confirmation is not explicit or the user declines, perform no writes and report the apply as skipped.
+
 ### Step 1: Direct Apply for Plan/Tasks Group
-1. Process all findings in the **Plan/Tasks Group** directly.
+1. After Step 0 confirmation, process all findings in the **Plan/Tasks Group** directly.
 2. Preserve feature intent and implementation scope.
 3. Add or refine task entries in `tasks.md` for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.
@@ -70,7 +75,7 @@ For multi-artifact findings, resolution is performed in authoritative order (`sp
 8. If an approved Constitution Update Proposal exists, reflect it as explicit follow-up work without auto-changing the Constitution itself.
 9. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
 
-### Step 2: Confirmation for Upstream Group
+### Step 2: Additional Confirmation for Upstream Group
 If the **Upstream Group** contains findings:
 1. Present a grouped summary table of upstream findings organized by target artifact (`proposal.md`, `spec.md`).
 2. Prompt the user for confirmation: `"Proceed with upstream artifact fixes? [Y/n]"`

--- a/commands/consolidate-specs.md
+++ b/commands/consolidate-specs.md
@@ -19,7 +19,8 @@ Generate `specs/system_context.md` as a compact offline fallback for Budgeted Ar
 3. If no source specs exist, report that no fallback was generated and leave any existing fallback untouched unless the user explicitly authorizes replacing it.
 4. Read each source only far enough to extract its title or one-line purpose, requirement and acceptance-criteria identifiers, shared invariants, cross-feature dependencies, and explicit conflicts. Acceptance-criteria bodies remain in the source spec.
 5. Deduplicate only statements that are clearly identical. Keep similar statements separate. Never resolve conflicts or ambiguity silently.
-6. Write the complete generated artifact in one operation with the structure below. Keep feature entries to one line plus identifiers and provenance so the fallback does not become another full specification.
+6. Report the resolved output path and preview the complete generated artifact without writing it.
+7. Request explicit user approval in a separate interaction before creating or replacing `system_context.md` at the resolved output path. On approval, write the complete artifact in one operation. Keep feature entries to one line plus identifiers and provenance so the fallback does not become another full specification.
 
 ## Required Output
 

--- a/commands/governed-archive.md
+++ b/commands/governed-archive.md
@@ -6,7 +6,7 @@ description: Verify, then archive a completed feature with explicit approval for
 
 ## SDD Adapter Resolution
 
-Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
+Before executing command, read `.specify/extensions/architecture-guard/adapters/resolve.md` (or `adapters/resolve.md` in a standalone install or source checkout). Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `.specify/extensions/architecture-guard/adapters/{tool}.md` (or `adapters/{tool}.md` in a standalone install or source checkout) for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
 
 ## Ponytail Core Contract
 
@@ -19,11 +19,11 @@ Verifies, then finalizes a completed feature. Changelog, memory, Git, and worksp
 ## Orchestration Flow
 
 ### Step 1 — Verification and SDD Framework Archival Execution
-- Determine the active framework via `adapters/resolve.md`.
+- Determine the active framework via `.specify/extensions/architecture-guard/adapters/resolve.md` (or `adapters/resolve.md` in a standalone install or source checkout).
 - Inspect `git status --short`, including uncommitted and untracked files, before any archive or consolidation action. Report which files belong to the feature and stop for explicit direction if their ownership or safety is ambiguous; never discard them.
 - **All frameworks**: Use the loaded adapter's `verify` mapping first and stop if verification fails or has unresolved blocking findings.
 - **If OpenSpec**: After verification and explicit approval, use the adapter's `archive` mapping; ask for the change name if it is ambiguous. Resolve and preview the destination first, fail on any destination collision, and never overwrite an existing archive.
-- **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in their native `specs/<feature>/` directory and incrementally update `specs/system_context.md`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
+- **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in the feature directory resolved by `{adapter_path:spec}` and incrementally update `{adapter_path:fallback-spec-index}`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
 - **If Generic**: Use the adapter's inline verification fallback. Explain that there is no native archive command, ask for an archive destination, preview it, and move artifacts only after explicit approval. Fail on destination collision and never overwrite existing content.
 - Track each archival sub-operation and its result. On partial failure, stop further destructive actions, preserve source artifacts, report completed and failed operations, and provide a safe resume or rollback procedure without claiming success.
 

--- a/commands/governed-archive.md
+++ b/commands/governed-archive.md
@@ -4,9 +4,9 @@ description: Verify, then archive a completed feature with explicit approval for
 
 # Governed Archive Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
 
 ## Ponytail Core Contract
 
@@ -19,11 +19,13 @@ Verifies, then finalizes a completed feature. Changelog, memory, Git, and worksp
 ## Orchestration Flow
 
 ### Step 1 — Verification and SDD Framework Archival Execution
-- Determine the active framework via `adapters/detect.md`.
+- Determine the active framework via `adapters/resolve.md`.
+- Inspect `git status --short`, including uncommitted and untracked files, before any archive or consolidation action. Report which files belong to the feature and stop for explicit direction if their ownership or safety is ambiguous; never discard them.
 - **All frameworks**: Use the loaded adapter's `verify` mapping first and stop if verification fails or has unresolved blocking findings.
-- **If OpenSpec**: After verification and explicit approval, use the adapter's `archive` mapping; ask for the change name if it is ambiguous.
+- **If OpenSpec**: After verification and explicit approval, use the adapter's `archive` mapping; ask for the change name if it is ambiguous. Resolve and preview the destination first, fail on any destination collision, and never overwrite an existing archive.
 - **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in their native `specs/<feature>/` directory and incrementally update `specs/system_context.md`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
-- **If Generic**: Use the adapter's inline verification fallback. Explain that there is no native archive command, ask for an archive destination, and move artifacts only after explicit approval.
+- **If Generic**: Use the adapter's inline verification fallback. Explain that there is no native archive command, ask for an archive destination, preview it, and move artifacts only after explicit approval. Fail on destination collision and never overwrite existing content.
+- Track each archival sub-operation and its result. On partial failure, stop further destructive actions, preserve source artifacts, report completed and failed operations, and provide a safe resume or rollback procedure without claiming success.
 
 ### Step 2 — Automated Changelog Update
 Parse the archived feature purpose and requirements into a proposed changelog entry. Ask for explicit approval before appending it to CHANGELOG.md or RELEASE_NOTES.md; if neither file exists, report that and do not create one silently.
@@ -41,7 +43,7 @@ Prompt the user to execute final Git operations:
 Prepare semantic commit messages and PR descriptions from the SDD artifacts, but execute Git operations only after the user selects an action and confirms the target branch and files.
 
 ### Step 5 — Workspace Cleanup
-If Git operations were successful, offer workspace cleanup as a separate confirmation. Never check out another branch or delete a feature branch without explicit approval.
+If Git operations were successful, enumerate each proposed cleanup action and affected path or branch, then require explicit approval for that exact list. Cleanup may include only the approved actions, such as removing confirmed temporary files, checking out a named branch, deleting a named local feature branch, or deleting a named remote feature branch. Never infer blanket approval, delete untracked work, check out another branch, or delete any branch without explicit approval.
 
 ## Output Structure
 
@@ -52,8 +54,11 @@ The command MUST return:
 
 ## Archival Status
 - **Framework**: [OpenSpec / SpecKit / etc.]
-- **Status**: [Success / Failed]
-- **Synced/Consolidated**: [Yes / No]
+- **Status**: [Success / Partial / Blocked / Failed / Retained In Place]
+- **Synced/Consolidated**: [Success / Partial / Skipped / Failed]
+- **Destination**: [Retained in place / archive path]
+- **Collision Check**: [Clear / Blocked]
+- **Partial Failure Recovery**: [Not needed / completed operations, failed operations, and resume or rollback steps]
 
 ## Changelog
 - **Status**: [Appended / Skipped]
@@ -66,4 +71,6 @@ The command MUST return:
 
 ## Workspace
 - **Status**: [Cleaned / Retained]
+- **Pre-Archive Changes**: [Uncommitted and untracked files inspected]
+- **Approved Cleanup**: [Enumerated actions / None]
 ```

--- a/commands/governed-delivery-team.md
+++ b/commands/governed-delivery-team.md
@@ -24,8 +24,12 @@ Produce an approved User Story and an implementation-ready `tasks.md` from an ac
 2. Flash-Mem context is retrieved before planning or task generation when the MCP server is available.
 3. The plan passes its architecture and applicable security gates before tasks are generated.
 4. Tasks are regenerated or reconciled whenever their source plan changes materially.
-5. Advisory findings remain non-blocking, while P0 architecture findings and Critical security findings stop progression.
+5. Advisory findings remain non-blocking, while Constitution P0 architecture findings and findings marked blocking by Security Review policy stop progression independently.
 6. A rerun resumes safely instead of recreating valid artifacts.
+
+## Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch, feature/change container, User Story, plan, and task artifacts together with all planned creation, status, linkage, generation, repair, and reconciliation operations. Obtain explicit user approval, then allow routine writes already previewed within this team-delivery phase scope without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
 
 ## Mandatory Branch Preflight
 
@@ -45,9 +49,10 @@ Before creating, planning, or modifying any active change:
 2. If no active feature directories exist (ignoring archives), automatically derive a kebab-case name from the user's goal and create the new feature directory using the active SDD tool's workflow.
 3. Do not guess when multiple feature directories are plausible. Ask the user to identify the feature.
 4. Detect `flash-mem` as an MCP service. Do not look for it in `.specify/extensions.yml`.
-5. Detect Security Review from `.specify/extensions.yml`. Accept `security-review` as the canonical extension id and `spec-kit-security-review` as a compatibility alias.
-6. Detect OpenSpec by looking for `openspec/config.yaml` or an `openspec` directory.
-7. Read constitution files directly when present because they may be ignored by repository search:
+5. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`. Manifest presence alone is not availability.
+6. For each phase, select the SpecKit integration only after verifying its applicable command is registered and callable: `/speckit.security-review.plan` for plan review and `/speckit.security-review.tasks` for task review. If an applicable command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability and use its corresponding plan or tasks operation. If neither path is callable, mark that phase's Security Review `Unavailable` and degrade without claiming a pass.
+7. Detect OpenSpec by looking for `openspec/config.yaml` or an `openspec` directory.
+8. Read constitution files directly when present because they may be ignored by repository search:
    - `.specify/memory/constitution.md`
    - `.specify/memory/architecture_constitution.md`
    - `.specify/memory/security_constitution.md`
@@ -87,8 +92,10 @@ Before engineering planning begins, generate a business-oriented User Story repr
 5. Present it for stakeholder review and stop before engineering planning until the user explicitly accepts it. Record the result as `approved` in the file.
 6. Once the User Story is approved, check for the presence of `.architecture-guard/sync.yml`. If it exists:
    - Run `npx tsx src/cli/validate-sync-config.ts` to strictly validate the configuration.
-   - If the configuration is valid and `enabled: true`, read the User Story content and push it to the configured provider (e.g., via your `github-mcp-server` to create an issue).
-   - Record the resulting issue ID or URL in `.architecture-guard/sync_status.json` (e.g., `{ "status": "success", "issue_url": "..." }`).
+   - If the configuration is valid and `enabled: true`, preview the configured provider and project/repository target and require explicit user approval of that target before any remote write.
+   - Before creating anything, inspect `.architecture-guard/sync_status.json` and query the approved target for an existing item linked to this User Story. Reuse a confirmed match; never create a duplicate. Reruns with unchanged content and a confirmed remote ID are a no-op, while changed content updates that same remote item when supported.
+   - After approval and duplicate checks, read the User Story content and create or update it through the configured provider (e.g., via `github-mcp-server`).
+   - Record `status: success` only after the provider returns and confirms a stable remote ID and URL. Persist that identity and target in `.architecture-guard/sync_status.json`; a missing or unconfirmed remote ID is a failed sync, not success.
    - If the push fails, write `{ "status": "failed" }` to `.architecture-guard/sync_status.json` and output a non-blocking warning. Do NOT stop the delivery workflow.
 7. If a previously approved User Story has been modified after engineering artifacts were generated, mark it `review-required`, warn the user, and require re-approval before proceeding.
 
@@ -107,7 +114,7 @@ Classify the plan:
 
 - `missing`: the design artifact (the technical design artifact, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
-- `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
+- `blocked`: an unresolved Constitution P0 architecture finding, independently blocking Security Review finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
 - `accepted`: the plan matches current inputs and has no unresolved blocking findings.
 
@@ -125,11 +132,11 @@ Do not use timestamps as the only evidence of material staleness. Compare artifa
 If the plan is `missing` or `stale`, execute the full `/ag-governed-plan` (or `/ag-governed-plan`) workflow.
 - **Linkage metadata**: When generating the new technical plan (the technical design artifact, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
-If the plan is `review-required`, reuse it and run the applicable security plan review plus `/ag-review-artifacts`. Do not regenerate a plan merely because review is needed.
+If the plan is `review-required`, reuse it and run the selected security plan operation plus `/ag-review-artifacts`. Recheck command or host-operation registration immediately before dispatch. Do not regenerate a plan merely because review is needed.
 
 - Continue automatically when there are no blocking findings.
 - Record advisory architecture drift without stopping.
-- Stop before task generation for unresolved P0 architecture or Critical security findings.
+- Stop before task generation for unresolved Constitution P0 architecture findings or independently blocking Security Review findings.
 - Stop when resolution requires a material product or architecture choice.
 - When a safe correction is already authorized, repair the plan, rerun affected reviews, and continue.
 
@@ -144,7 +151,7 @@ If tasks are `missing`, `stale`, or `review-required`, execute `/ag-governed-tas
 The governed task phase must:
 
 1. Generate or reconcile `tasks.md` through `/speckit.tasks` (or the SDD tool's native task generator/inline fallback).
-2. Run the applicable security task review.
+2. Run the selected security tasks operation, after rechecking that the command or host operation is registered.
 3. Convert confirmed architecture findings into explicit work through `ag-refactor-generator`.
 4. Run analysis (e.g., `/speckit.analyze`) against the complete plan and task set if available in the SDD tool.
 5. Keep implementation, security, migration, and refactor work explicit.
@@ -155,9 +162,9 @@ If analysis exposes a plan defect, mark the plan and tasks stale, return to the 
 
 When Flash-Mem is available:
 
-1. Capture changed durable artifacts with `capture_artifact_memory` using the appropriate source type.
-2. Add or update durable memory only for validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns.
-3. Do not store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
+1. Propose artifact captures and durable-memory entries, showing their sources and content summary.
+2. Execute `capture_artifact_memory`, `add_memory`, or `update_memory` only after explicit user approval.
+3. Store only validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns; never store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
 
 ## Output
 

--- a/commands/governed-delivery.md
+++ b/commands/governed-delivery.md
@@ -23,8 +23,12 @@ Produce an implementation-ready `tasks.md` from an accepted technical plan while
 1. Flash-Mem context is retrieved before planning or task generation when the MCP server is available.
 2. The plan passes its architecture and applicable security gates before tasks are generated.
 3. Tasks are regenerated or reconciled whenever their source plan changes materially.
-4. Advisory findings remain non-blocking, while P0 architecture findings and Critical security findings stop progression.
+4. Advisory findings remain non-blocking, while Constitution P0 architecture findings and findings marked blocking by Security Review policy stop progression independently.
 5. A rerun resumes safely instead of recreating valid artifacts.
+
+## Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch, change container, specification or proposal, plan, and task artifacts together with all planned creation, generation, repair, and reconciliation operations. Obtain explicit user approval, then allow routine writes already previewed within this delivery phase scope without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
 
 ## Mandatory Branch Preflight
 
@@ -44,9 +48,10 @@ Before creating, planning, or modifying any active change:
 2. If no active feature directories or specifications exist (ignoring archives), run the adapter-registered `governed-spec` capability (or `/speckit.specify`) to properly initialize the feature workspace and specification following native SDD tool numbering rules.
 3. Do not guess when multiple feature directories are plausible. Ask the user to identify the feature.
 4. Detect `flash-mem` as an MCP service. Do not look for it in `.specify/extensions.yml`.
-5. Detect Security Review from `.specify/extensions.yml`. Accept `security-review` as the canonical extension id and `spec-kit-security-review` as a compatibility alias.
-6. Detect OpenSpec by looking for `openspec/config.yaml` or an `openspec` directory.
-7. Read constitution files directly when present because they may be ignored by repository search:
+5. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`. Manifest presence alone is not availability.
+6. For each phase, select the SpecKit integration only after verifying its applicable command is registered and callable: `/speckit.security-review.plan` for plan review and `/speckit.security-review.tasks` for task review. If an applicable command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability and use its corresponding plan or tasks operation. If neither path is callable, mark that phase's Security Review `Unavailable` and degrade without claiming a pass.
+7. Detect OpenSpec by looking for `openspec/config.yaml` or an `openspec` directory.
+8. Read constitution files directly when present because they may be ignored by repository search:
    - `.specify/memory/constitution.md`
    - `.specify/memory/architecture_constitution.md`
    - `.specify/memory/security_constitution.md`
@@ -82,7 +87,7 @@ Classify the plan:
 
 - `missing`: the design artifact (the technical design artifact, `design.md`, or `proposal.md`) does not exist or is empty.
 - `stale`: `spec.md` or governing constraints changed materially after the plan was produced.
-- `blocked`: an unresolved P0 architecture finding, Critical security finding, or material design decision prevents safe task generation.
+- `blocked`: an unresolved Constitution P0 architecture finding, independently blocking Security Review finding, or material design decision prevents safe task generation.
 - `review-required`: the plan exists but has not been validated against current inputs.
 - `accepted`: the plan matches current inputs and has no unresolved blocking findings.
 
@@ -99,11 +104,11 @@ Do not use timestamps as the only evidence of material staleness. Compare artifa
 
 If the plan is `missing` or `stale`, execute the full `/ag-governed-plan` (or `/ag-governed-plan`) workflow.
 
-If the plan is `review-required`, reuse it and run the applicable security plan review plus `/ag-review-artifacts`. Do not regenerate a plan merely because review is needed.
+If the plan is `review-required`, reuse it and run the selected security plan operation plus `/ag-review-artifacts`. Recheck command or host-operation registration immediately before dispatch. Do not regenerate a plan merely because review is needed.
 
 - Continue automatically when there are no blocking findings.
 - Record advisory architecture drift without stopping.
-- Stop before task generation for unresolved P0 architecture or Critical security findings.
+- Stop before task generation for unresolved Constitution P0 architecture findings or independently blocking Security Review findings.
 - Stop when resolution requires a material product or architecture choice.
 - When a safe correction is already authorized, repair the plan, rerun affected reviews, and continue.
 
@@ -118,7 +123,7 @@ If tasks are `missing`, `stale`, or `review-required`, execute `/ag-governed-tas
 The governed task phase must:
 
 1. Generate or reconcile `tasks.md` through `/speckit.tasks` (or the SDD tool's native task generator/inline fallback).
-2. Run the applicable security task review.
+2. Run the selected security tasks operation, after rechecking that the command or host operation is registered.
 3. Convert confirmed architecture findings into explicit work through `ag-refactor-generator`.
 4. Run analysis (e.g., `/speckit.analyze`) against the complete plan and task set if available in the SDD tool.
 5. Keep implementation, security, migration, and refactor work explicit.
@@ -129,9 +134,9 @@ If analysis exposes a plan defect, mark the plan and tasks stale, return to the 
 
 When Flash-Mem is available:
 
-1. Capture changed durable artifacts with `capture_artifact_memory` using the appropriate source type.
-2. Add or update durable memory only for validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns.
-3. Do not store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
+1. Propose artifact captures and durable-memory entries, showing their sources and content summary.
+2. Execute `capture_artifact_memory`, `add_memory`, or `update_memory` only after explicit user approval.
+3. Store only validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns; never store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
 
 ## Output
 

--- a/commands/governed-discover.md
+++ b/commands/governed-discover.md
@@ -31,12 +31,15 @@ Provide a single command that ensures:
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- Security Review integration
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment.
-2. Read `.specify/extensions.yml` and check the `installed` list for `security-review` (or compatibility alias `spec-kit-security-review`). If present, note it for downstream security flagging.
-3. If either capability is missing, degrade gracefully. Without `flash-mem`, rely on the local `.specify/memory/architecture_constitution.md` and `.specify/memory/security_constitution.md` files.
+2. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`.
+3. Manifest presence is not availability. Treat the SpecKit integration as available only if at least one phase command needed downstream (`/speckit.security-review.plan`, `/speckit.security-review.tasks`, or `/speckit.security-review.branch`) is registered and callable.
+4. If no applicable SpecKit command is registered, detect an independently registered Architecture Guard-compatible Security Review host capability with a corresponding plan, tasks, or branch operation.
+5. Record the available operations for downstream security flagging; discovery need not invoke them. If neither path is callable, record Security Review as `Unavailable` and degrade without claiming a pass.
+6. If either optional integration is missing, degrade gracefully. Without `flash-mem`, rely on the local `.specify/memory/architecture_constitution.md` and `.specify/memory/security_constitution.md` files.
 
 ### Step 2 — Architecture Context Retrieval
 
@@ -45,6 +48,8 @@ Retrieve the most relevant architectural context for the user's idea before star
 ### Step 3 — Current Implementation Review (Optional)
 
 If the user's prompt suggests modifying an existing feature, analyze the current codebase for that feature to ensure the proposed ideas fit seamlessly with the existing patterns.
+
+Keep this review read-only and scan for boundary drift, duplicated business rules or orchestration (DRY risk), misplaced/generated artifacts, temporary files, and repository hygiene risks. Carry findings into the handoff; do not modify the repository.
 
 ### Step 4 — Interactive Discussion Loop
 
@@ -58,7 +63,7 @@ Enter an interactive Q&A discussion with the user.
 
 If required questions remain unresolved, ask only the next necessary questions and do not produce the final handoff draft yet.
 
-If the user proposes a feature that touches authentication, authorization, PII, or data exposure, and `security-review` (or compatibility alias `spec-kit-security-review`) was detected in Step 1, flag the idea for downstream security review.
+If the user proposes a feature that touches authentication, authorization, PII, secrets, trust boundaries, or data exposure, always mark it security-sensitive in the handoff. If Security Review was detected in Step 1, flag it for downstream review; otherwise retain the security-sensitive flag and mark Security Review `Unavailable`.
 
 ### Step 4.5 — Durable Memory Proposal
 
@@ -97,6 +102,12 @@ When the discussion is concluded and aligned, the command MUST return:
 ## Open Questions
 - [Non-blocking questions that can be resolved during governed-spec]
 
+## Security-Sensitive Areas
+- [Auth, PII, secrets, trust boundaries, or data-exposure concerns; state "None identified" only after checking]
+
+## DRY & Repository Hygiene Risks
+- [Duplicate ownership, repeated logic, misplaced/generated artifacts, temporary files, or "None identified"]
+
 ## Recommended Next Step
 To proceed to implementation and avoid a "Feature: Not selected" error, you must initialize the feature using the active SDD tool's workflow (e.g., creating a new OpenSpec change) before running a delivery phase.
 
@@ -122,8 +133,8 @@ You can now run:
 - Fall back to reading `.specify/memory/architecture_constitution.md` and `.specify/memory/security_constitution.md` directly
 
 **Without Security Review**:
-- Skip security-relevant flagging in Step 4
-- Note missing security context in the Discovery Summary Draft
+- Still flag security-sensitive ideas for downstream review, but mark Security Review `Unavailable`
+- Note missing security review capability in the Discovery Summary Draft; do not claim a pass
 
 **Minimal Viable Workflow** (only Architecture Guard):
 - Read constitution files directly

--- a/commands/governed-implement.md
+++ b/commands/governed-implement.md
@@ -4,6 +4,10 @@ description: Execute implementation tasks, then review the result against availa
 
 # Governed Implement Command
 
+## SDD Adapter Resolution
+
+Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
+
 ## Ponytail Core Contract
 
 Before continuing, you **MUST** read and apply `.specify/extensions/architecture-guard/templates/ponytail_core.md` (or `templates/ponytail_core.md` in the extension source checkout) as the authoritative shared contract. Phase instructions may narrow but not weaken its safety or verification floor.
@@ -26,16 +30,23 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact code, test, and task artifacts together with all planned implementation, test, and task-checkbox operations. Obtain explicit user approval, then allow routine writes already previewed within this implementation phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- Security Review integration
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment. Do not treat it as a Spec Kit extension or look for it in `.specify/extensions.yml`.
-2. Read `.specify/extensions.yml` and check the `installed` list for `security-review` (or compatibility alias `spec-kit-security-review`). Fall back to checking for the extension directory in `.specify/extensions/` only if the YAML is missing or the list is empty.
-3. If either capability is missing, degrade gracefully by skipping only its respective steps.
+2. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`.
+3. Manifest presence is not availability. If either name is installed, verify that `/speckit.security-review.branch` is registered and callable before selecting it.
+4. If that command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability with a branch operation and select it instead.
+5. If neither path is callable, mark Security Review `Unavailable` and degrade without claiming a pass.
+6. If either optional integration is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
@@ -82,8 +93,8 @@ NOTE: The core Spec Kit command is `speckit.implement`. Do not use `speckit.impl
 
 ### Step 4 — Security Review on Implementation
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `/speckit.security-review.branch` to review the produced implementation against security vulnerabilities.
+IF Security Review is available:
+1. **Execute Review**: Invoke `/speckit.security-review.branch` when selected; otherwise dispatch the selected host capability's branch operation.
 2. Check for: authorization bypass, missing validation, secret leakage, injection risk, and insecure data exposure.
 3. If security findings are architecture-relevant, classify them as `Security-Architecture Conflict` for the architecture review.
 
@@ -104,17 +115,16 @@ Review implementation against:
 **Critical Decision Point**: Evaluate architecture findings for blocking issues.
 
 ```
-IF Architecture Review finds CRITICAL or HIGH violations:
-  IF Constitution marks violation as P0 (blocking):
-    STOP implementation
-    Surface violations in report
-    Ask user: "Critical architecture violation detected. Proceed? (y/n)"
-    IF user says no:
-      Return early with architecture remediation tasks
-  ELSE (violation is HIGH but not Constitution P0):
-    Continue with warning
-    Create non-blocking refactor tasks
-    Flag for post-merge remediation
+IF Constitution marks an architecture violation as P0 (blocking):
+  STOP implementation with no override path
+  Surface violations and return architecture remediation tasks
+ELSE IF Security Review reports a blocking finding under its own policy:
+  STOP implementation independently of architecture severity
+  Surface security findings and return security remediation guidance
+ELSE IF Architecture Review finds CRITICAL or HIGH violations:
+  Continue with warning when they are not Constitution P0
+  Create non-blocking refactor tasks
+  Flag for post-merge remediation
 ELSE (no critical violations):
   Continue to Step 6
 ```
@@ -128,13 +138,17 @@ IF architecture violations exist:
 2. Generate non-blocking refactor, migration, or correction tasks.
 3. Skip performance refactors unless explicitly requested.
 
-### Step 7 — Proactive Durable Memory Preservation
+### Step 7 — Mandatory Verification Gate
+
+Run `/ag-verify` after implementation and reviews. Do not mark implementation complete or ready to merge until verification passes with no unresolved blocking findings. If `/ag-verify` is not registered and callable, execute the workflow in `verify.md` inline and report the fallback. Stop and return remediation guidance when verification reports any blocking finding.
+
+### Step 8 — Proactive Durable Memory Preservation
 
 If the implementation review or security audit identified new architectural patterns, critical decisions, or repeatable lessons:
-1. **Proactive Execution**: You **MUST automatically execute** the durable-memory capture flow as the final part of this turn. Do not just recommend it; run the command.
-2. **Standard**: Do not silently write memory outside the capture flow; let the formal capture flow propose entries and handle user approval. Do not ask the user if they want to capture; identify the lessons and trigger the command immediately after the summary.
+1. **Approval Required**: Propose validated durable-memory entries and write them only after explicit user approval.
+2. **Standard**: Do not silently write memory outside the approved capture flow.
 
-### Step 8 — Implementation Governance Summary
+### Step 9 — Implementation Governance Summary
 
 Produce a final `Governed Implementation Summary`.
 
@@ -148,7 +162,11 @@ Produce a final `Governed Implementation Summary`.
 **Without Security Review**:
 - Skip Step 4 (Security Review on Implementation)
 - Continue to architecture review directly
-- Flag missing security implementation review in summary
+- Report Security Review as `Unavailable` and flag missing security implementation review in the summary; do not claim a pass
+
+**Blocking Security Findings Found**:
+- STOP independently when the registered Security Review capability marks a finding blocking under its policy.
+- Do not downgrade, merge, or override that decision through Architecture Guard severity handling.
 
 **Critical Architecture Violations Found**:
 - If Constitution marks as P0 (blocking):
@@ -164,6 +182,7 @@ Produce a final `Governed Implementation Summary`.
 - Execute implementation via core Spec Kit
 - Run architecture review on output
 - Generate non-blocking refactor tasks
+- Pass mandatory verification, using the inline fallback when `/ag-verify` is unavailable
 - Produce summary
 
 ## Output Structure
@@ -178,9 +197,10 @@ The command MUST return:
 - **Relevant Decisions**: [Durable lessons applied during implementation]
 
 ## Security Review
+- **Status**: [Reviewed / Advisory / Blocked / Unavailable]
 - **Findings**: [List of security vulnerabilities found]
 - **Constraints**: [Trust boundaries validated]
-- **Blocking Concerns**: [Any P0 security risks]
+- **Blocking Concerns**: [Findings marked blocking by Security Review policy]
 
 ## Architecture Review
 - **Violations**: [Drift findings or Security-Architecture Conflicts]
@@ -194,8 +214,8 @@ The command MUST return:
 - [e.g., Merge changes]
 - [e.g., Revise implementation to address Security Conflict]
 - [e.g., Run /ag-apply]
-- **Durable Memory Preservation**: (Proactively triggered) Review the proposed memory entries below.
-- **Verification Gate**: Run `/ag-verify` to ensure all tasks are delivered and requirements are met.
+- **Durable Memory Preservation**: [Approved and captured / Awaiting approval / Skipped]
+- **Verification Gate**: [Passed / Blocked / Inline fallback passed]
 ```
 
 ## Security + Architecture Conflict Handling

--- a/commands/governed-implement.md
+++ b/commands/governed-implement.md
@@ -6,7 +6,7 @@ description: Execute implementation tasks, then review the result against availa
 
 ## SDD Adapter Resolution
 
-Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
+Before executing command, read `.specify/extensions/architecture-guard/adapters/resolve.md` (or `adapters/resolve.md` in a standalone install or source checkout). Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `.specify/extensions/architecture-guard/adapters/{tool}.md` (or `adapters/{tool}.md` in a standalone install or source checkout) for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
 
 ## Ponytail Core Contract
 

--- a/commands/governed-plan.md
+++ b/commands/governed-plan.md
@@ -26,18 +26,29 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact target plan and constraint artifacts together with all planned generation, correction, and constraint-write operations. Obtain explicit user approval, then allow routine writes already previewed within this planning phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
+### Required Active Inputs
+
+Require the active feature `spec.md` plus `.specify/memory/constitution.md`, `.specify/memory/architecture_constitution.md`, and `.specify/memory/security_constitution.md`. If the active specification, governance rules, or architecture rules are missing, stop and direct the user to `/ag-governed-spec` or `/ag-init`; if security rules are missing, report the gap and obtain explicit confirmation before baseline security validation.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
 - Memory MD local CLI
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- Security Review integration
 
 **Detection Logic**:
 1. Treat `flash-mem` as available only when its MCP tools are already exposed in the current environment. Do not treat it as a Spec Kit extension, look for it in `.specify/extensions.yml`, or repeatedly probe for hidden MCP/global-promotion capabilities.
 2. Check for the Memory MD runtime directly with `test -f .specify/extensions/memory-md/dist/bin/speckit-memory.js`. If present, invoke supported local operations with `node .specify/extensions/memory-md/dist/bin/speckit-memory.js <command>`. Do not use default `rg --files` to decide that this runtime is missing: `dist/` and `node_modules/` may be gitignored. If additional discovery is necessary, use `find` or `rg --files -uu`.
-3. Read `.specify/extensions.yml` and check the `installed` list for `security-review` (or compatibility alias `spec-kit-security-review`). Fall back to checking for the extension directory in `.specify/extensions/` only if the YAML is missing or the list is empty.
-4. If an optional capability is missing, degrade gracefully by skipping only its respective steps. A missing Flash-Mem MCP service does not make an available Memory MD CLI unavailable.
+3. Inspect the installed list in `.specify/extensions.yml` for the canonical `security-review` extension or compatibility alias `spec-kit-security-review`.
+4. Manifest presence is not availability. If either extension name is installed, verify that `/speckit.security-review.plan` is registered and callable before selecting the SpecKit integration.
+5. If that command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability with a plan operation and select it instead.
+6. If neither path is callable, mark Security Review `Unavailable` and degrade without claiming a pass.
+7. If an optional capability is missing, degrade gracefully by skipping only its respective steps. A missing Flash-Mem MCP service does not make an available Memory MD CLI unavailable.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
@@ -86,8 +97,8 @@ You must orchestrate the `/speckit.plan` workflow directly.
 
 ### Step 4 — Security Review (Optional)
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `/speckit.security-review.plan` to review the plan and save `specs/<feature>/security-constraints.md`.
+IF Security Review is available:
+1. **Execute Review**: Invoke `/speckit.security-review.plan` when selected; otherwise dispatch the selected host capability's plan operation. Preview the exact `specs/<feature>/security-constraints.md` changes and require explicit user approval before writing them.
 2. Focus on:
     - Trust boundaries and authorization assumptions.
     - Data isolation and validation risks.
@@ -106,13 +117,13 @@ Inputs to consider:
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).
 
-Detect any `Security-Architecture Conflict` or architectural drift.
+Detect any `Security-Architecture Conflict` or architectural drift. Explicitly validate one canonical owner for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration (DRY), plus artifact placement, temporary/generated files, and repository hygiene.
 
 ### Step 6 — Proactive Durable Memory Preservation
 
 If the planning process or architecture validation identified new architectural patterns, critical decisions, or repeatable lessons:
 1. **Capability Gate**: Use a Flash-Mem write tool only when that tool is already exposed in the current environment. Otherwise, if the Memory MD CLI detected in Step 1 supports the required local capture operation, use `node .specify/extensions/memory-md/dist/bin/speckit-memory.js <command>`.
-2. **Proactive Execution**: When either explicit capture path is available, you **MUST automatically execute** that durable-memory capture flow as the final action of this turn. Do not just recommend it; run the command.
+2. **Approval Required**: When either explicit capture path is available, propose the durable-memory entries and write them only after explicit user approval.
 3. **Bounded Degradation**: Do not probe for Flash-Mem, `speckit_memory_share_lesson`, another MCP wrapper, or global/shared promotion when such a capability is not already exposed. Complete any available local capture or synthesis, report global promotion as unavailable, and finish the governed workflow.
 4. **Standard**: Do not silently write memory outside an available formal capture flow; let that flow propose entries and handle user approval when its interface requires approval.
 
@@ -131,7 +142,7 @@ Produce a final `Governed Planning Summary` for the user.
 **Without Security Review**:
 - Skip Step 4 (Security Review)
 - Continue to violation-detection directly
-- Flag missing security validation in governance summary
+- Report Security Review as `Unavailable` and flag missing security validation in the governance summary; do not claim a pass
 - Plan-level review proceeds with architecture constraints only
 
 **Minimal Viable Workflow** (only Architecture Guard + Spec Kit):
@@ -154,7 +165,7 @@ The command MUST return:
 - **Key Constraints**: [Bullet points of architectural context used]
 
 ## Security Review
-- **Status**: [Reviewed / Skipped]
+- **Status**: [Reviewed / Advisory / Blocked / Unavailable]
 - **Constraints Found**: [Key security-architecture boundaries]
 - **Warnings**: [Any high-risk authorization or isolation issues]
 
@@ -173,5 +184,6 @@ The command MUST return:
 
 - **SDD-Tool-Agnostic**: Do not assume specific SDD tool conventions unless provided via a preset.
 - **Non-Blocking**: Findings should be advisory by default unless they violate a P0 rule in the Constitution.
+- **Independent Security Policy**: Preserve Security Review severity and blocking decisions independently from architecture severity and P0 handling.
 - **Incremental**: Prefer suggestions for incremental migration over full rewrites.
 - **Decoupled**: Do not tightly couple the logic to the internals of other extensions; rely on documented context and repository artifacts.

--- a/commands/governed-spec.md
+++ b/commands/governed-spec.md
@@ -27,27 +27,39 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch and target artifacts for feature creation, specification generation, clarification updates, and any `system_context.md` refresh, together with the planned operations. Obtain explicit user approval, then allow routine writes already previewed within this specification phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- Security Review integration
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment.
-2. Read `.specify/extensions.yml` and check the `installed` list for `security-review` (or compatibility alias `spec-kit-security-review`).
-3. If either capability is missing, degrade gracefully by skipping only its respective steps.
+2. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`.
+3. Manifest presence is not availability. Treat the SpecKit integration as available only if at least one phase command needed downstream (`/speckit.security-review.plan`, `/speckit.security-review.tasks`, or `/speckit.security-review.branch`) is registered and callable.
+4. If no applicable SpecKit command is registered, detect an independently registered Architecture Guard-compatible Security Review host capability with a corresponding plan, tasks, or branch operation.
+5. Record available operations and flag security-sensitive specification content for the applicable downstream review; this workflow need not invoke a phase command because it has no dedicated Security Review execution step.
+6. If neither path is callable, record Security Review as `Unavailable` and degrade without claiming a pass.
+7. If either optional integration is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
 When Flash-Mem is available, use it first to gather the most relevant architectural context before generating the specification.
 
+### Step 2.5 — Required Governance Inputs
+
+Require `.specify/memory/constitution.md`, `.specify/memory/architecture_constitution.md`, and `.specify/memory/security_constitution.md` as active inputs. If governance or architecture rules are missing, stop and direct the user to `/ag-init`. If security rules are missing, report the gap and require explicit confirmation before continuing with baseline security checks and the available Security Review handoff.
+
 ### Step 3 — Branch Management
 
 Before generating the specification, you MUST ensure work happens on a feature branch.
 1. Check the current git branch.
-2. If on `main`, `master`, `dev*` (e.g., `dev`, `develop`, `development`), or `staging`, ask the user if they want to create a new branch for this feature.
-3. If they approve, create the branch using available tools before proceeding.
+2. If on `main`, `master`, `dev*` (e.g., `dev`, `develop`, `development`), or `staging`, require approval to create or select a feature branch before any specification write.
+3. Stop if approval is declined or branch creation, selection, or checkout fails.
 
 ### Step 4 — Orchestrate Spec Kit Specification
 
@@ -73,13 +85,14 @@ Inputs to consider:
 - `.specify/memory/architecture_constitution.md`.
 - Flash-Mem context (if available).
 
-Detect any `Security-Architecture Conflict` or architectural drift present in the specification's assumptions or boundaries.
+Detect any `Security-Architecture Conflict` or architectural drift present in the specification's assumptions or boundaries. Explicitly validate one canonical owner for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration (DRY), plus artifact placement, temporary/generated files, and repository hygiene.
 
 ### Step 7 — Proactive Durable Memory Preservation
 
 If the specification process or architecture validation identified new architectural patterns or critical decisions:
-1. **Proactive Execution**: You **MUST automatically execute** the durable-memory capture flow.
-2. **Standard**: Do not silently write memory outside the capture flow; let the formal capture flow propose entries and handle user approval.
+1. **Proactive Proposal**: You **MUST automatically launch** the durable-memory capture flow in proposal-only mode.
+2. **Approval Required**: Show the proposed entries and obtain explicit user approval before invoking any memory write tool.
+3. **Standard**: Do not silently write memory inside or outside the capture flow.
 
 ### Step 8 — Generate Governance Summary
 
@@ -110,6 +123,7 @@ The command MUST return:
 - **Key Constraints**: [Bullet points of architectural context used]
 
 ## Architecture & Security Review
+- **Security Review Availability**: [Available operations / Unavailable]
 - **Violations Detected**: [Drift findings, missing boundaries, or Security-Architecture Conflicts in the spec]
 - **Consistency Risks**: [How the specification aligns with the Constitution]
 

--- a/commands/governed-tasks.md
+++ b/commands/governed-tasks.md
@@ -28,16 +28,27 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact target task and constraint artifacts together with all planned task-generation, reconciliation, refactor, analysis-fix, and constraint-write operations. Obtain explicit user approval, then allow routine writes already previewed within this task phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
+### Required Active Inputs
+
+Require the active feature specification and technical design artifacts plus `.specify/memory/constitution.md`, `.specify/memory/architecture_constitution.md`, and `.specify/memory/security_constitution.md`. If the specification, design, governance rules, or architecture rules are missing, stop and direct the user to the corresponding governed phase or `/ag-init`; if security rules are missing, report the gap and obtain explicit confirmation before baseline security task validation.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- Security Review integration
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment. Do not treat it as a Spec Kit extension or look for it in `.specify/extensions.yml`.
-2. Read `.specify/extensions.yml` and check the `installed` list for `security-review` (or compatibility alias `spec-kit-security-review`). Fall back to checking for the extension directory in `.specify/extensions/` only if the YAML is missing or the list is empty.
-3. If either capability is missing, degrade gracefully by skipping only its respective steps.
+2. Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`.
+3. Manifest presence is not availability. If either name is installed, verify that `/speckit.security-review.tasks` is registered and callable before selecting it.
+4. If that command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability with a tasks operation and select it instead.
+5. If neither path is callable, mark Security Review `Unavailable` and degrade without claiming a pass.
+6. If either optional integration is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
@@ -84,12 +95,12 @@ You must orchestrate the `/speckit.tasks` workflow directly.
 
 ### Step 4 — Security Review on Tasks
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `/speckit.security-review.tasks` to review the task list.
+IF Security Review is available:
+1. **Execute Review**: Invoke `/speckit.security-review.tasks` when selected; otherwise dispatch the selected host capability's tasks operation.
 2. Check for missing tasks related to:
     - Validation, authorization, and trust boundaries.
     - Secure integration and audit/logging.
-3. Update `specs/<feature>/security-constraints.md` with any new findings.
+3. Preview the exact `specs/<feature>/security-constraints.md` changes and require explicit user approval before writing them.
 
 ### Step 5 — Architecture Refactor Generation
 
@@ -108,13 +119,15 @@ It MUST convert architecture findings into:
 You must orchestrate the `/speckit.analyze` workflow directly to serve as the formal analyst.
 
 1. **Execute Analyze**: Run `/speckit.analyze` on the complete task list and architecture refactors.
-2. **Architecture Validation**: Detect any gaps, missing requirements, or high-severity execution risks present in the implementation plan or task list.
+2. **Architecture Validation**: Detect any gaps, missing requirements, or high-severity execution risks present in the implementation plan or task list. Explicitly verify DRY coverage for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration, plus repository hygiene and required cleanup/placement tasks.
+3. **Task Identity Reconciliation**: After adding security or refactor work, ensure every task has one unique, stable sequential ID; update references without reusing or silently renumbering completed IDs.
 
 ### Step 7 — Proactive Durable Memory Preservation
 
 If the task generation or security review identified new architectural lessons or reusable patterns:
-1. **Proactive Execution**: You **MUST automatically execute** the durable-memory capture flow as the final part of this turn. Do not just recommend it; run the command.
-2. **Standard**: Do not silently write memory outside the capture flow; let the formal capture flow propose entries and handle user approval.
+1. **Proactive Proposal**: You **MUST automatically launch** the durable-memory capture flow in proposal-only mode as the final part of this turn.
+2. **Approval Required**: Show the proposed entries and obtain explicit user approval before invoking any memory write tool.
+3. **Standard**: Do not silently write memory inside or outside the capture flow.
 
 ### Step 8 — Task Governance Summary
 
@@ -123,9 +136,10 @@ Produce a final `Governed Tasks Summary` for the user.
 ### Step 9 — Automatic Analyst Loop
 
 If the analyst (`/speckit.analyze`) finds any gaps, missing steps, or high severity issues in Step 6:
-1. **Pause and Ask**: Conclude your response by asking the user:
+1. **Blocking Gate**: If any finding is a Constitution P0 architecture violation or independently policy-designated blocking security finding, stop progression, surface remediation tasks, and do not allow a simple proceed prompt to override it.
+2. **Pause and Ask for Advisory Findings**: For remaining non-blocking findings, conclude your response by asking the user:
    > *"The analyst found [number] gaps/severities in the tasks. Would you like me to automatically clarify and revise the tasks to address these findings?"*
-2. **Execute if Approved**: If the user answers "yes" (or equivalent) in their next message, you must:
+3. **Execute if Approved**: If the user answers "yes" (or equivalent) in their next message, you must:
    - Automatically rewrite `specs/<feature>/tasks.md` to resolve the detected gaps.
    - Present the clean result.
 
@@ -139,7 +153,7 @@ If the analyst (`/speckit.analyze`) finds any gaps, missing steps, or high sever
 **Without Security Review**:
 - Skip Step 4 (Security Review on Tasks)
 - Continue to refactor-generator directly
-- Flag missing security task validation in summary
+- Report Security Review as `Unavailable` and flag missing security task validation in the summary; do not claim a pass
 
 **If No Architecture Violations**:
 - Report "Architecture refactor tasks: None"
@@ -163,6 +177,7 @@ The command MUST return:
 - **Relevant Decisions**: [List of historical constraints affecting these tasks]
 
 ## Security Task Review
+- **Status**: [Reviewed / Advisory / Blocked / Unavailable]
 - **Missing Security Tasks**: [List of missing auth/val/audit tasks]
 - **Constraints**: [Key security boundaries to respect]
 
@@ -183,3 +198,4 @@ The command MUST return:
 - **Separation**: Clearly separate implementation tasks, security tasks, and architecture refactor tasks.
 - **Precision**: Do NOT merge findings into vague task items.
 - **Non-Blocking**: Findings are advisory by default.
+- **Independent Security Policy**: Preserve Security Review severity and blocking decisions independently from architecture findings.

--- a/commands/init-brownfield.md
+++ b/commands/init-brownfield.md
@@ -23,7 +23,7 @@ Create a reliable current-state baseline before any architectural or delivery gu
 3. Note any current conventions, constraints, and risky areas.
 4. Capture known gaps between the current codebase and the desired governance model.
 5. Identify existing pragmatic patterns (Ponytail principles: YAGNI, standard library preference, minimal abstractions) to preserve in the constitution.
-6. Produce an initial brownfield plan instead of assuming a greenfield setup.
+6. Produce a **Brownfield Recommendation Outline** instead of assuming a greenfield setup.
 7. Count and estimate the size of active `specs/**/spec.md` files, excluding generated or explicitly archived artifacts.
 8. Offer Budgeted Architecture Context Retrieval when repeated historical-spec loading is likely to be material.
 
@@ -33,13 +33,14 @@ Create a reliable current-state baseline before any architectural or delivery gu
 - System boundaries and dependency map
 - Existing conventions and exceptions
 - Migration or refactor candidates
-- First-pass plan for bringing the project under governance
+- Brownfield Recommendation Outline for bringing the project under governance
 
 ## Guidance
 
 - Prefer observation over assumption.
 - Treat existing code as the source of truth.
 - Keep the first pass lightweight and non-destructive.
+- Establish a read-only baseline of current boundary drift, security-sensitive areas and trust boundaries, duplicated business rules or orchestration (DRY risk), and repository hygiene issues such as misplaced, generated, or temporary artifacts.
 - Ask for confirmation before suggesting broad refactors.
 - Recommend targeted mode for small spec sets. For larger histories, explain that budgeted mode queries Flash-Mem first, loads `specs/system_context.md` only as an offline fallback, and never replaces active feature artifacts.
 - If the user wants budgeted mode, record the recommendation in the brownfield output and hand it to `/ag-init`. Do not create configuration or generate `system_context.md` during this non-destructive mapping pass.

--- a/commands/init.md
+++ b/commands/init.md
@@ -426,10 +426,10 @@ Are you working on this project as a solo developer, or as part of a team?
 ```
 
 If the user selects Team Development:
-1. Write `Mode: Team` into the governance rules (e.g., `openspec/config.yaml` or `.specify/memory/constitution.md`).
-2. Ask: "Which issue tracker MCP server should be used to sync User Stories? (e.g., github-mcp-server, jira, none)". Save this preference in the governance rules.
-3. Automatically scaffold a `user-stories/` directory at the project root to house global business requirements.
-4. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira). Then, automatically scaffold the `.architecture-guard/sync.yml` file configuring the chosen provider, the project/repo string, and `enabled: true`.
+1. Ask: "Which issue tracker MCP server should be used to sync User Stories? (e.g., github-mcp-server, jira, none)".
+2. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira).
+3. Preview the exact proposed governance changes and team scaffolding, including `Mode: Team`, the tracker preference, `user-stories/`, and `.architecture-guard/sync.yml` when applicable.
+4. Require explicit user approval of that preview before writing governance rules or creating any team scaffolding. If approval is declined, make no team-mode writes.
 
 ---
 
@@ -808,6 +808,8 @@ DO NOT generate final documents until:
 * enough information has been collected
 * OR the user explicitly requests a draft
 
+Before creating, modifying, deleting, moving, or scaffolding any file or directory, show the exact target paths and proposed operations and obtain explicit user approval.
+
 ---
 
 # Output Requirements
@@ -820,7 +822,7 @@ Generate or refine:
 
 When Budgeted Architecture Context Retrieval is selected, also generate `.specify/config/architecture_guard.yml`. Missing configuration means targeted mode, preserving backward compatibility.
 
-If the `flash-mem` MCP server is available, you MUST run the `update_project_summary` tool to reflect any major changes in architecture, boundaries, or governance rules in the project summary. If it is unavailable, rely on the repository files directly and continue without the sync step.
+If the `flash-mem` MCP server is available, propose `update_project_summary` for major changes in architecture, boundaries, or governance rules and execute it only after explicit user approval. If it is unavailable, rely on the repository files directly and continue without the sync step.
 
 ---
 

--- a/commands/refactor-generator.md
+++ b/commands/refactor-generator.md
@@ -14,7 +14,9 @@ Convert architecture violations into structured tasks that preserve delivery mom
 
 ## Flash-Mem-First Architecture Context Retrieval
 
-When Flash-Mem is available, call `get_project_summary`, then `search_memory`; prefer summaries and metadata and load full entries only as needed. Reuse approved decisions and flag conflicts. After analysis, store only validated durable architecture knowledge. If retrieval is unavailable or insufficient, fall back to repository artifacts and constitution files.
+When Flash-Mem is available, call `get_project_summary`, then `search_memory`; prefer summaries and metadata and load full entries only as needed. Reuse approved decisions and flag conflicts. After analysis, propose only validated durable architecture knowledge and write it only after explicit user approval. If retrieval is unavailable or insufficient, fall back to repository artifacts and constitution files.
+
+This command does not write files or memory. Return proposed tasks and durable-memory candidates for approval; use a separate write-capable flow only after explicit user approval.
 
 Use the same normalized command context as the review workflow. When `mode=performance`, do not invent refactor tasks from performance guidance; that mode is advisory and belongs to `ag-review-implementation` output only.
 
@@ -102,7 +104,7 @@ Suggested fixes should be concrete:
 
 ### Incremental Migration Strategy
 When generating refactor tasks based on architecture drift, you MUST avoid proposing full system rewrites. Prefer incremental, boundary-by-boundary, or module-by-module migrations.
-Output your phased migration strategy to `specs/<feature>/architecture-migration-plan.md`. Include coexistence strategies for old and new patterns.
+Propose a phased migration strategy for `specs/<feature>/architecture-migration-plan.md`. Do not write it until the user explicitly approves the proposed content. Include coexistence strategies for old and new patterns.
 
 ## Architecture Migration Plan Structure
 

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -6,13 +6,13 @@ description: Review specification and planning artifacts against architectural r
 
 ## SDD Adapter Resolution
 
-Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+Before executing this command, read `.specify/extensions/architecture-guard/adapters/resolve.md` (or `adapters/resolve.md` in a standalone install or source checkout). Resolve the active adapter in this order:
 
 1. An explicit `--adapter` override, when provided.
 2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
 3. Filesystem markers only when no persisted selection exists.
 
-Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` token before reading review artifacts. Stop if the adapter is missing or any token remains unresolved.
+Load `.specify/extensions/architecture-guard/adapters/{tool}.md` (or `adapters/{tool}.md` in a standalone install or source checkout) and resolve every `{adapter_path:key}` token before reading review artifacts. Stop if the adapter is missing or any token remains unresolved.
 
 ## Ponytail Core Contract
 

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -4,13 +4,23 @@ description: Review specification and planning artifacts against architectural r
 
 # Architecture Review Command
 
+## SDD Adapter Resolution
+
+Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+
+1. An explicit `--adapter` override, when provided.
+2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
+3. Filesystem markers only when no persisted selection exists.
+
+Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` token before reading review artifacts. Stop if the adapter is missing or any token remains unresolved.
+
 ## Ponytail Core Contract
 
 Before continuing, you **MUST** read and apply `.specify/extensions/architecture-guard/templates/ponytail_core.md` (or `templates/ponytail_core.md` in the extension source checkout) as the authoritative shared contract. Phase instructions may narrow but not weaken its safety or verification floor.
 
 ## Budgeted Context Contract
 
-Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `.specify/extensions/architecture-guard/templates/budgeted_context.md` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification, design, and task documents (the exact filenames depend on the active SDD tool), security constraints, and applicable constitutions are authoritative. Use fallback provenance to open historical planning artifacts only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -79,10 +89,10 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 ## Semantic Modeling
 
 Before analysis, build internal representations (do not output these):
-1. **Boundary Model**: Map the expected boundaries (Entry, Application, Domain, Data, External) vs. actual directory structure.
-2. **Contract Inventory**: Identify shared data shapes, API signatures, and event structures.
-3. **Task-Implementation Map**: Map `tasks.md` IDs to specific code files and check completion status.
-4. **Dependency Graph**: Map module-to-module dependencies to detect coupling or layering violations.
+1. **Planned Boundary Model**: Map boundaries proposed by the specification and design (Entry, Application, Domain, Data, External).
+2. **Planned Contract Inventory**: Identify data shapes, API signatures, and event structures described by the artifacts.
+3. **Task Coverage Map**: Map `tasks.md` IDs to planned requirements, boundaries, and deliverables without checking implementation.
+4. **Planned Dependency Graph**: Map proposed module dependencies to detect design-time coupling or layering violations.
 
 ## Review Principles
 
@@ -100,13 +110,13 @@ Use these core principles to detect drift:
 ## Detection Scope
 
 Detect violations such as:
-- **Intent Divergence**: Implementation deviates fundamentally from the specification or design intent.
-- **Hallucinated Abstractions**: Plan mentions an abstraction (e.g., Repository) that is missing in code.
+- **Intent Divergence**: The design or tasks deviate fundamentally from specification intent.
+- **Unsupported Abstractions**: The plan introduces an abstraction without specification, design, or task justification.
 - **Boundary Erosion**: Business logic leaking into entry points or UI.
 - **Tight Coupling**: Circular dependencies or cross-module leakage.
 - **Duplication Drift**: The same rule, validation, mapping, or workflow is implemented in multiple places instead of a shared boundary.
 - **Contract Mismatch**: Mismatch between API, UI, or service shapes.
-- **Ponytail Violation (Bloat)**: Code is over-engineered, duplicates an existing capability, adds avoidable files or dependencies, includes unnecessary boilerplate or future-proofing, or bypasses a correct standard-library or native-platform feature.
+- **Ponytail Violation (Bloat)**: The plan is over-engineered, duplicates a planned capability, adds avoidable files or dependencies, includes unnecessary boilerplate or future-proofing, or bypasses a documented standard-library or native-platform option.
 - **Ponytail Violation (Unsafe Simplification)**: A small diff removes required validation, authorization, data-loss prevention, accessibility, external-system safeguards, or verification.
 - **Root-Cause Miss**: A symptom is patched in one caller while sibling callers remain exposed to the same shared defect.
 - **Constitution Breach**: Any conflict with a "MUST" principle in the Constitution.
@@ -129,7 +139,7 @@ Detect violations such as:
 4. **Scan Principles**: Apply Review Principles across the planned boundaries.
 5. **Target Classification**: Determine which artifact each finding targets based on the finding's source evidence. Emit the adapter-resolved filename: `plan.md` for SpecKit planning artifacts, `design.md` for OpenSpec design artifacts, and the applicable `proposal.md`, `spec.md`, or `tasks.md` otherwise. For multi-artifact findings, set `Target:` to the authoritative artifact (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`).
 6. **Security & Governance Cross-Check**:
-  - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
+  - Assign security finding severity and blocking status from the active security policy; do not fix severity by category.
   - Cross-reference architecture decisions with security trust boundaries.
 7. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
 8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
@@ -144,7 +154,7 @@ Every violation MUST cite evidence or explicitly note its absence. Evidence can 
 - **Pattern**: Behavioral observation like `All 5 proposed endpoints lack standard response contract definitions`
 - **Absence**: Missing planning detail like `Task references Repository pattern but no data access module is planned`
 
-**Absence Evidence** is acceptable for CRITICAL violations only. Example:
+**Absence Evidence** is acceptable when active governance policy assigns the resulting violation CRITICAL severity. Example:
 - "Constitution requires data access abstraction but the technical design artifact does not specify one"
 
 For all other violations, cite specific planning locations, lines, or patterns. Vague claims like "business logic is leaking" without specific evidence are insufficient.
@@ -153,7 +163,8 @@ For all other violations, cite specific planning locations, lines, or patterns. 
 
 ## Severity Guide
 
-- **CRITICAL**: Violates Constitution MUST, breaches Security Constraint, or has zero implementation evidence for a required boundary.
+- **CRITICAL**: Violates a Constitution P0/MUST rule or meets another Critical condition in active governance policy.
+- **Security severity**: Use the active security policy's severity and independent blocking semantics.
 - **HIGH**: Significant boundary erosion, contract inconsistency, or fundamental intent divergence.
 - **MEDIUM**: Pattern drift or local inconsistency that creates technical debt.
 - **LOW**: Minor naming, shape, or structure drift.
@@ -164,14 +175,14 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Target | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `.specify/memory/architecture_constitution.md` | `plan.md` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
+| ID | Category | Severity | Blocking | Location(s) | Target | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | [Yes/No, from policy] | `.specify/memory/architecture_constitution.md` | `plan.md` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
 
-### Task Synchronization
-- **Status**: [Synced / Drifted]
-- **Missing Implementations**: [Files referenced in tasks but missing/empty]
-- **Pending Tasks**: [Incomplete tasks blocking architecture]
+### Task Coverage
+- **Status**: [Covered / Gaps Found]
+- **Missing Planned Work**: [Requirements or design elements without task coverage]
+- **Pending Planning Decisions**: [Unresolved artifact decisions blocking architecture]
 
 ### Metrics
 - **Constitution Compliance**: [e.g. 90%]
@@ -217,7 +228,7 @@ Findings categorized by severity based on the active hygiene rules.
 1. **Critical Fixes**: Address Constitution and Security violations first.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
-4. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
+4. **Durable Memory Preservation (Mandatory Check)**: Keep memory read-only during review. If new architectural patterns, decisions, or repeatable lessons were identified, include proposed entries in the report. After returning the report, request explicit approval in a separate interaction and write only approved entries.
 5. **Next Step**: Run `/ag-apply` to resolve all findings (plan/tasks findings will be applied directly; upstream findings in `proposal.md` or `spec.md` will be delegated with confirmation).
 6. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -6,13 +6,13 @@ description: Review implementation code or pre-implementation planning artifacts
 
 ## SDD Adapter Resolution
 
-Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+Before executing this command, read `.specify/extensions/architecture-guard/adapters/resolve.md` (or `adapters/resolve.md` in a standalone install or source checkout). Resolve the active adapter in this order:
 
 1. An explicit `--adapter` override, when provided.
 2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
 3. Filesystem markers only when no persisted selection exists.
 
-Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` and `{adapter_command:key}` token before reviewing changed files or implementation artifacts. Stop if the adapter is missing or any token remains unresolved.
+Load `.specify/extensions/architecture-guard/adapters/{tool}.md` (or `adapters/{tool}.md` in a standalone install or source checkout) and resolve every `{adapter_path:key}` and `{adapter_command:key}` token before reviewing changed files or implementation artifacts. Stop if the adapter is missing or any token remains unresolved.
 
 ## Ponytail Core Contract
 

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -4,6 +4,16 @@ description: Review implementation code or pre-implementation planning artifacts
 
 # Architecture Review Command
 
+## SDD Adapter Resolution
+
+Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+
+1. An explicit `--adapter` override, when provided.
+2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
+3. Filesystem markers only when no persisted selection exists.
+
+Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` and `{adapter_command:key}` token before reviewing changed files or implementation artifacts. Stop if the adapter is missing or any token remains unresolved.
+
 ## Ponytail Core Contract
 
 Before continuing, you **MUST** read and apply `.specify/extensions/architecture-guard/templates/ponytail_core.md` (or `templates/ponytail_core.md` in the extension source checkout) as the authoritative shared contract. Phase instructions may narrow but not weaken its safety or verification floor.
@@ -79,7 +89,8 @@ This pattern ensures that lower-tier models follow strict execution paths instea
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Changed Files**:
    - If the user provided a file list or explicit instructions, follow them.
-   - Otherwise, you **MUST** execute `architecture-guard detect-changed-files --json` to detect changed files since the merge-base or in the working directory.
+   - Otherwise, use `architecture-guard detect-changed-files --json` only after confirming that capability is available.
+   - If unavailable, derive the set with the host's Git capability: include committed changes from the merge-base to `HEAD`, staged changes, unstaged changes, and untracked files. If Git is unavailable, ask the user for a file list and report that automatic detection could not run.
    - Use the `changed_files` list as the primary review set.
 
 ## Input & Context Loading
@@ -154,14 +165,16 @@ Detect violations such as:
 
 ## Review Procedure
 
-1. **Identify Scope**: Run `architecture-guard detect-changed-files --json` or use user-provided files.
+1. **Identify Scope**: Reuse the scope resolved by **Determine Review Scope**: user-provided files first, then the changed-files capability, then the host Git fallback; ask the user when none is available.
 2. **Model Context**: Load artifacts and build the Semantic Models for the identified scope.
 3. **Verify Evidence**: Check if task-referenced files exist and contain expected implementation logic.
 4. **Analyze Alignment**: Compare the initial specification intent vs. the proposed architectural design vs. implementation behavior. Ensure the implementation accurately satisfies the spec without violating constraints.
 5. **Scan Principles**: Apply Review Principles across the implemented boundaries.
 6. **Security & Governance Cross-Check**:
-  - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
-  - If a finding is primarily security-related and Security Review is available, route it to `/speckit.security-review.branch` instead of duplicating it here.
+  - Assign security finding severity and blocking status from the active security policy rather than fixing severity by category.
+  - Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`. Manifest presence is not availability: invoke `/speckit.security-review.branch` only after verifying that it is registered and callable.
+  - If that command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability and dispatch its branch operation for security-first findings instead of duplicating them here.
+  - If neither path is callable, report Security Review as `Unavailable`, degrade without claiming a pass, and do not substitute architecture findings for the missing review.
   - Cross-reference architecture decisions with security trust boundaries.
 7. **Ponytail Audit**: Apply both sides of the shared contract. Check for bloat and unsafe under-building; trace changed shared behavior to its callers; verify the earliest viable ladder rung was used; and confirm non-trivial logic has a runnable check.
 8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
@@ -210,7 +223,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 
 **If inline**:
 1. **Load Rules**: Read the installed extension bundle at `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
-2. **Scan Changed Files**: Simulate or invoke SonarLint logic on `changed_files` list
+2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)
 5. **Deduplicate**: If a violation is already in architecture violations list, suppress from SonarLint output
@@ -235,7 +248,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 Add a new section in the report (see Output Format below):
 
 ```markdown
-### Code Quality Findings (SonarLint)
+### Code Quality Findings ([SonarLint / Heuristic Sonar Rules Analysis])
 
 Findings that correlate with architecture concerns:
 
@@ -263,7 +276,8 @@ For all other violations, cite specific code locations, line numbers, or pattern
 
 ## Severity Guide
 
-- **CRITICAL**: Violates Constitution MUST, breaches Security Constraint, or has zero implementation evidence for a required boundary.
+- **CRITICAL**: Violates a Constitution P0/MUST rule or meets another Critical condition in active governance policy.
+- **Security findings**: Retain severity and independent blocking status from the active Security Review policy.
 - **HIGH**: Significant boundary erosion, contract inconsistency, or fundamental intent divergence.
 - **MEDIUM**: Pattern drift or local inconsistency that creates technical debt.
 - **LOW**: Minor naming, shape, or structure drift.
@@ -274,9 +288,9 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `.specify/memory/architecture_constitution.md` | Violation of [Principle Name] | [Evidence from code/plan] |
+| ID | Category | Severity | Blocking | Location(s) | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | [Yes/No, from policy] | `.specify/memory/architecture_constitution.md` | Violation of [Principle Name] | [Evidence from code/plan] |
 
 ### Task Synchronization
 - **Status**: [Synced / Drifted]
@@ -305,8 +319,8 @@ Return only this structure:
 - **Suggestion**: 
 - **Trade-off**: 
 
-(Only if `mode=architecture` and SonarLint findings detected)
-### Code Quality Findings (SonarLint)
+(Only if `mode=architecture` and code-quality findings were produced)
+### Code Quality Findings ([SonarLint / Heuristic Sonar Rules Analysis])
 
 Findings that correlate with architecture concerns:
 
@@ -341,8 +355,8 @@ Findings categorized by severity based on the active hygiene rules.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **Code Quality**: Address SonarLint findings that map to architectural concerns (if any).
 4. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
-5. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
-6. **Next Step**: [e.g. Run `/speckit.security-review.branch` for security-first findings, or `/ag-apply` for architecture fixes]
+5. **Durable Memory Preservation (Mandatory Check)**: Keep memory read-only during review. If new architectural patterns, decisions, or repeatable lessons were identified, include proposed entries in the report. After returning the report, request explicit approval in a separate interaction and write only approved entries.
+6. **Next Step**: [e.g. Dispatch the selected Security Review branch operation for security-first findings, or run `/ag-apply` for architecture fixes]
 7. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 
 ## Framework Preset Guidance

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -46,6 +46,8 @@ Build internal representations:
 - **Task-Boundary Map**: Associate each task with its intended architecture layer (Entry, Application, Domain, Data, External).
 - **Implementation Evidence**: For each completed task (`[x]`), scan referenced files for logic that addresses the task description.
 - **Contract Inventory**: Extract planned API/Data signatures from the design artifact (the technical design artifact, `design.md`, or `proposal.md`).
+- **Requirement/Acceptance Evidence Map**: Map every specification requirement and acceptance criterion to tasks and concrete implementation or test evidence.
+- **Artifact Consistency Check**: Compare specification, design, plan, tasks, and security constraints for contradictions that make implementation intent or acceptance ambiguous.
 - **Duplication Check**: Look for repeated business logic, validation, or transformation across files and confirm it has been centralized or explicitly justified.
 
 **Common DRY Signals**
@@ -69,28 +71,50 @@ Build internal representations:
 - **Rule Check**: Does the implementation violate any "MUST" rules in the `architecture_constitution.md`?
 - **Pattern Match**: Does the code follow the mandated architectural patterns (e.g., DTOs, Repositories, Events)?
 
-#### D. Security Review on Implementation
-- If `security-review` (or compatibility alias `spec-kit-security-review`) is available, run `/speckit.security-review.branch` against the verified implementation.
-- If security findings are architecture-relevant, classify them as `Security-Architecture Conflict`.
+#### D. Requirement and Artifact Integrity
+- **Coverage Gaps**: Requirements or acceptance criteria without task and implementation/test evidence.
+- **Contradictions**: Conflicting requirements, contracts, boundaries, or completion claims across authoritative artifacts. Mark contradictions blocking when they prevent reliable acceptance or safe implementation verification.
 
-#### E. Repository Hygiene Validation
+#### E. Security Review on Implementation
+- Inspect the installed list in `.specify/extensions.yml` for `security-review` or its compatibility alias `spec-kit-security-review`.
+- Manifest presence is not availability. If either name is installed, invoke `/speckit.security-review.branch` only after verifying that command is registered and callable.
+- If that command is absent, detect an independently registered Architecture Guard-compatible Security Review host capability and dispatch its branch operation.
+- If neither path is callable, report Security Review as `Unavailable`, degrade without claiming a pass, and do not substitute an Architecture Guard scan.
+- If security findings are architecture-relevant, classify them as `Security-Architecture Conflict`.
+- Preserve Security Review's independent severity and blocking decision.
+
+#### F. Repository Hygiene Validation
 - Run all loaded hygiene rules against the repository, respecting configured exclusions from `repository_hygiene` config.
 - If a finding's severity matches the `fail_on` list in the configuration, elevate it to CRITICAL to fail the verification gate.
 - Other findings should be reported as Warnings or Info based on their base severity or the `warn_on` configuration.
 
 ### 4. Severity Assignment
 
-- **CRITICAL**: Task marked done but implementation is missing; Constitution "MUST" violation; Boundary bypass (e.g., direct DB access from UI).
+- **CRITICAL**: Task marked done but implementation is missing; Constitution P0/MUST violation; or another condition marked Critical by active governance policy.
+- **Security findings**: Retain severity and independent blocking status from the active Security Review policy.
 - **HIGH**: Contract mismatch; Missing error-handling/edge-cases from spec; Major boundary erosion; repeated business rules with no shared extraction.
 - **MEDIUM**: Pattern drift; Task-referenced file exists but logic is incomplete.
 - **LOW**: Naming inconsistencies; Minor structure drift.
 
 ## Verification Report
 
-| ID | Category | Severity | Location(s) | Target | Summary | Recommendation |
-|:---|:---|:---|:---|:---|:---|:---|
-| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
-| V2 | Boundary | HIGH | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
+| ID | Category | Severity | Blocking | Status | Location(s) | Target | Summary | Recommendation |
+|:---|:---|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Task Integrity | CRITICAL | Yes | Open | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
+| V2 | Boundary | HIGH | No | Open | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
+
+### Requirement and Acceptance Evidence
+For each requirement and acceptance criterion:
+- **Source**: [Artifact and requirement/criterion ID]
+- **Tasks**: [Mapped task IDs]
+- **Evidence**: [Implementation and test locations]
+- **Status**: [Verified / Partial / Missing / Contradicted]
+- **Blocking**: [Yes/No under active governance policy]
+
+### Artifact Contradictions
+- **Contradiction**: [Conflicting artifact statements or None]
+- **Blocking**: [Yes/No]
+- **Resolution Required**: [Authoritative artifact and decision needed]
 
 ### Task Status Analysis
 For each task in `tasks.md`:

--- a/commands/violation-detection.md
+++ b/commands/violation-detection.md
@@ -14,11 +14,11 @@ Your role is to identify architectural drift in specifications, plans, and imple
 
 ## Flash-Mem-First Architecture Context Retrieval
 
-When Flash-Mem is available, call `get_project_summary`, then `search_memory`; prefer summaries and metadata and load full entries only as needed. Reuse approved decisions and flag conflicts. After analysis, store only validated durable architecture knowledge. If retrieval is unavailable or insufficient, fall back to repository artifacts and constitution files.
+When Flash-Mem is available, call `get_project_summary`, then `search_memory`; prefer summaries and metadata and load full entries only as needed. Reuse approved decisions and flag conflicts. After analysis, propose only validated durable architecture knowledge and write it only after explicit user approval. If retrieval is unavailable or insufficient, fall back to repository artifacts and constitution files.
 
 ## Operating Constraints
 
-- **STRICTLY READ-ONLY**: This command is analytical. Do **not** modify any files.
+- **STRICTLY READ-ONLY**: This command is analytical. Do **not** modify files or memory. Durable-memory candidates may be proposed, but require explicit user approval before a separate write.
 - **Progressive Disclosure**: Load context incrementally. Start with design artifacts before deep-diving into code.
 - **Evidence-Based**: Every violation must cite specific "Implementation Evidence" (file paths, line numbers, or code patterns) or its absence.
 
@@ -90,7 +90,7 @@ Before analysis, build internal representations (do not output these):
 
 ## Security-Architecture Conflict (Detailed)
 
-A Security-Architecture Conflict occurs when security requirements and architecture boundaries create opposing design constraints. These must be flagged with **CRITICAL** severity and routed to both security and architecture workflows.
+A Security-Architecture Conflict occurs when security requirements and architecture boundaries create opposing design constraints. Assign severity from the active security and governance policies, and route the finding to both security and architecture workflows. A blocking Security Review decision remains independently blocking.
 
 ### Examples
 
@@ -127,7 +127,8 @@ A Security-Architecture Conflict occurs when security requirements and architect
 4. **Scan Principles**: Apply detection scope across boundaries and contracts.
 5. **Security & Governance Cross-Check**: Ensure architecture decisions do not violate `security_constitution.md` or `security-constraints.md`.
 6. **Assign Severity**:
-   - `Critical`: Constitution MUST breach (including Security), Security Constraint violation, or zero evidence for a required boundary.
+   - `Critical`: Constitution P0/MUST breach or another condition marked Critical by active policy.
+   - Security findings use the active security policy's severity and blocking semantics rather than a fixed category mapping.
    - `High`: Significant boundary erosion, contract inconsistency, or intent divergence.
    - `Medium`: Local drift or debt.
    - `Low`: Minor shape or naming drift.
@@ -140,6 +141,8 @@ Return only:
 Violations:
 - Type:
   Severity:
+  Blocking: [Yes / No, from governing policy]
+  Priority: [P0 only when explicitly policy-blocking / P1 / P2 / P3]
   Location:
   Description:
   Evidence:

--- a/commands/workflow.md
+++ b/commands/workflow.md
@@ -33,7 +33,7 @@ Try Flash-Mem first: query summary and metadata context before performing archit
 3. Load full memory content only when summaries are insufficient.
 4. Reuse approved architectural decisions whenever possible.
 5. Flag conflicts between proposed changes and existing architectural decisions.
-6. After analysis, store durable architecture knowledge back into Flash-Mem:
+6. After analysis, propose durable architecture knowledge for Flash-Mem and write only entries the user explicitly approves:
    - new architecture decisions
    - approved exceptions
    - recurring violations
@@ -51,7 +51,7 @@ The workflow is serial and ownership-aware:
 2. Normalize `mode` and `focus` from the incoming command.
 3. Run the architecture review against the Constitution, memory synthesis, and generic architecture principles.
 4. If `mode=performance`, keep the pass advisory and route output to `Performance Insights` only.
-5. Route security-first findings to Security Review instead of duplicating them here.
+5. For the current artifact phase, inspect `.specify/extensions.yml` for `security-review` or `spec-kit-security-review`, then verify the applicable command is registered before invoking it: `/speckit.security-review.plan` for plans, `/speckit.security-review.tasks` for tasks, and `/speckit.security-review.branch` for implementation. Manifest presence alone is not availability. If the command is absent, dispatch the corresponding operation from an independently registered Architecture Guard-compatible Security Review host capability. If neither path is callable, report `Unavailable`, degrade without claiming a pass, and route security-first findings as unresolved handoffs instead of duplicating them here.
 6. Treat repeated business rules, approvals, validation, DTO mapping, or orchestration as DRY drift and route it to refactor extraction rather than allowing parallel copies.
    - Prefer one shared source of truth for the repeated rule, contract, transformation, or decision.
 7. If `mode=architecture` and a Constitution Update Proposal is warranted, surface it and leave application to `ag-apply`.
@@ -84,7 +84,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 1. Read Flash-Mem context first if it is available in the project or workflow context, then fall back to repository files if needed.
 2. Review the current work against the Constitution and generic architecture principles.
 3. Identify whether any finding is primarily security-related.
-4. If a finding is security-related, flag it as a handoff to Security Review rather than treating it as a core architecture finding.
+4. If a finding is security-related, use the compatibility chain above for the current artifact phase and flag it as a Security Review handoff rather than treating it as a core architecture finding.
 5. Produce refactor tasks or an apply recommendation as needed.
 6. Prefer a single concise summary that tells the user what to fix next.
 
@@ -93,9 +93,11 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 - Do not invent SDD-tool-specific conventions.
 - Do not invent unsupported SDD tool APIs.
 - Do not block implementation by default.
+- Constitution P0 architecture findings are non-overridable and stop progression until remediated.
 - Do not replace Security Review; route security-first findings to Security Review when available.
 - Do not require `flash-mem`; treat it as optional read-only context only.
 - Do not duplicate Security Review findings in the architecture output unless the issue is specifically an architectural boundary problem.
+- Preserve Security Review severity and blocking decisions independently from architecture severity and P0 handling.
 - Do not write security follow-up items into architecture tasks or plan updates.
 - Do not write memory conclusions into architecture follow-up items.
 
@@ -110,7 +112,7 @@ All governance reports MUST follow this standard template:
 
 ## Input Summary
 - **Artifacts Scanned**: [list]
-- **Extensions Used**: [`flash-mem`: yes/no, Security Review: yes/no]
+- **Extensions Used**: [`flash-mem`: yes/no, Security Review: SpecKit/host/Unavailable]
 - **Mode**: [architecture/performance]
 - **Focus**: [general/db/api/async]
 
@@ -127,7 +129,7 @@ All governance reports MUST follow this standard template:
 
 ## Context Applied
 - **`flash-mem`**: [Used context or "Not available"]
-- **Security Review**: [Findings routed or "Not available"]
+- **Security Review**: [Findings routed or `Unavailable`; never infer a pass from manifest presence]
 
 ## Recommended Next Step
 [Single clear action]

--- a/docs/standalone-usage.md
+++ b/docs/standalone-usage.md
@@ -50,7 +50,7 @@ Select SDD tool or workflow:
   3. none (generic Markdown workflow)
 ```
 
-Architecture Guard detects your SDD tool at runtime from filesystem markers:
+Architecture Guard uses the adapter selected during CLI initialization:
 
 | SDD Tool or Workflow | Detection Marker | Works When |
 | :--- | :--- | :--- |
@@ -58,9 +58,9 @@ Architecture Guard detects your SDD tool at runtime from filesystem markers:
 | **OpenSpec** | `openspec/config.yaml` exists | OpenSpec projects |
 | **Generic** | No known markers, or user declines | Any project |
 
-Detection runs at the start of every orchestration command. It never overwrites your filesystem markers. If both `.specify/` and `openspec/` exist, it asks which adapter to use.
+The selected adapter is persisted in `.architecture-guard/selected-adapter` and loaded at the start of every orchestration command. Filesystem markers are inspected only when no selection exists. If both markers exist during first-time initialization, the user must choose an adapter.
 
-Override detection with `--adapter` in the command itself, or select the SDD tool explicitly via the CLI installer.
+Override the persisted adapter for one command with `--adapter`, or change the persisted selection by rerunning the CLI installer with a new `--framework`.
 
 ## 4. Choose Your Commands
 
@@ -91,7 +91,7 @@ You can select one, several, or `all`. The installer writes only the commands yo
 After you select agents, an SDD tool or workflow, and commands, `install.js` writes:
 
 - **Command files** in your agent's directory (markdown, skill, TOML, or YAML)
-- **Adapters** — `adapters/detect.md` plus your SDD tool's adapter (e.g., `adapters/openspec.md`, `adapters/spec-kit.md`)
+- **Adapters** — `adapters/resolve.md` plus your SDD tool's adapter (e.g., `adapters/openspec.md`, `adapters/spec-kit.md`)
 - **Runtime resources** — `templates/`, `presets/`, `hygiene-rules/`, `sonar-rules/` under `.architecture-guard/`
 - **`AGENTS.md` governance rules** (optional — the installer offers on completion)
 
@@ -141,11 +141,11 @@ architecture-guard init /path/to/project --yes --agent claude --framework opensp
 
 The target argument specifies which directory to install into (default: current directory).
 
-## 8. SDD Tool Detection in Practice
+## 8. SDD Adapter Resolution in Practice
 
 When an orchestration command runs, it:
 
-1. Reads `adapters/detect.md` and scans project root for SDD tool markers
+1. Reads `adapters/resolve.md` and loads the persisted adapter selection
 2. Loads `adapters/{tool}.md` — the adapter for that SDD tool
 3. Resolves every `{adapter_path:key}` and `{adapter_command:key}` from the adapter
 4. Executes the command body using adapter-resolved paths and commands
@@ -153,7 +153,7 @@ When an orchestration command runs, it:
 The same orchestration command `governed-spec` creates:
 
 - SpecKit project: `specs/<feature>/spec.md` via `/speckit.specify`
-   - OpenSpec project: `openspec/changes/{change}/specs/{capability}/spec.md` via `openspec new change` + inline spec writes
+- OpenSpec project: `openspec/changes/{change}/specs/{capability}/spec.md` via `openspec new change` + inline spec writes
 
 You choose the SDD tool once; Architecture Guard adapts the rest.
 

--- a/install.test.ts
+++ b/install.test.ts
@@ -136,6 +136,23 @@ test('rejects missing runtime resources with actionable error', () => {
   }
 });
 
+test('reports missing canonical prompts without a stack trace', () => {
+  const orchestration = path.join(__dirname, '..', 'orchestration');
+  const moved = orchestration + ".test-backup";
+  fs.renameSync(orchestration, moved);
+  try {
+    const result = spawnSync(process.execPath, [installer, 'init', '--yes', '--agent', 'opencode', '--framework', 'spec-kit', '--commands', 'init'], {
+      cwd: fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-')),
+      encoding: 'utf8',
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Error: Canonical orchestration prompt not found/);
+    assert.doesNotMatch(result.stderr, /at installCommand/);
+  } finally {
+    fs.renameSync(moved, orchestration);
+  }
+});
+
 test('escapes TOML triple quotes and emits safe YAML metadata', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
   const toml = path.join(cwd, 'test.toml');

--- a/install.test.ts
+++ b/install.test.ts
@@ -7,6 +7,54 @@ const { spawnSync } = require('node:child_process');
 
 const installer = path.join(__dirname, 'bin', 'cli.js');
 
+test('standalone orchestration and legacy Spec Kit extension expose the same skills', () => {
+  const root = path.join(__dirname, '..');
+  const manifest = require('yaml').parse(fs.readFileSync(path.join(root, 'extension.yml'), 'utf8'));
+  const legacyFiles = manifest.provides.commands.map(command => command.file);
+  const legacyNames = legacyFiles.map(file => path.basename(file)).sort();
+  const orchestrationNames = fs.readdirSync(path.join(root, 'orchestration'))
+    .filter(file => file.endsWith('.md'))
+    .sort();
+  const installerNames = require('./cli/install').COMMANDS
+    .map(command => `${command}.md`)
+    .sort();
+
+  assert.deepEqual(legacyNames, orchestrationNames);
+  assert.deepEqual(installerNames, orchestrationNames);
+  for (const file of legacyFiles) {
+    assert.ok(fs.existsSync(path.join(root, file)), `Missing legacy Spec Kit prompt: ${file}`);
+  }
+});
+
+test('Security Review stays in the legacy Spec Kit extension channel', () => {
+  const root = path.join(__dirname, '..');
+  const cases = [
+    ['governed-plan.md', 'plan'],
+    ['governed-tasks.md', 'tasks'],
+    ['governed-implement.md', 'branch'],
+    ['verify.md', 'branch'],
+    ['review-implementation.md', 'branch'],
+  ];
+
+  for (const [file, operation] of cases) {
+    const prompt = fs.readFileSync(path.join(root, 'commands', file), 'utf8');
+    assert.match(prompt, /\.specify\/extensions\.yml/);
+    assert.match(prompt, /spec-kit-security-review/);
+    assert.match(prompt, new RegExp(`/speckit\\.security-review\\.${operation}`));
+    assert.match(prompt, /Architecture Guard-compatible Security Review host capability/);
+    assert.match(prompt, /Unavailable/);
+  }
+
+  const specKitAdapter = fs.readFileSync(path.join(root, 'adapters', 'spec-kit.md'), 'utf8');
+  assert.match(specKitAdapter, /Unsupported in standalone SDD orchestration/);
+  assert.doesNotMatch(specKitAdapter, /\/speckit\.security-review\./);
+
+  for (const file of fs.readdirSync(path.join(root, 'orchestration')).filter(file => file.endsWith('.md'))) {
+    const prompt = fs.readFileSync(path.join(root, 'orchestration', file), 'utf8');
+    assert.doesNotMatch(prompt, /spec-kit-security-review|\/speckit\.security-review\./);
+  }
+});
+
 function install(input, cwd) {
   const result = spawnSync(process.execPath, [installer, 'init'], { cwd, input, encoding: 'utf8' });
   assert.equal(result.status, 0, result.stderr);
@@ -20,7 +68,7 @@ test('installs every agent format at the project root with selected resources on
   assert.equal(Object.keys(require('./cli/install').AGENT_CONFIGS).length, 35);
   assert.ok(fs.existsSync(path.join(cwd, '.opencode/commands/ag-init.md')));
   assert.ok(!fs.existsSync(path.join(cwd, cwd.slice(1), '.opencode/commands/ag-init.md')));
-  assert.ok(fs.existsSync(path.join(cwd, 'adapters/detect.md')));
+   assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
   assert.ok(fs.existsSync(path.join(cwd, 'adapters/spec-kit.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/openspec.md')));
   assert.equal(fs.readFileSync(path.join(cwd, '.architecture-guard/selected-adapter'), 'utf8').trim(), 'spec-kit');
@@ -43,7 +91,7 @@ test('existing commands skip by default, replace, or keep both', () => {
   install('1\n3\n2\n3\n\nn\n', cwd);
   assert.equal(fs.readFileSync(dest, 'utf8'), 'original');
   assert.ok(fs.existsSync(path.join(cwd, '.opencode/commands/ag-init.architecture-guard.md')));
-  assert.ok(fs.existsSync(path.join(cwd, 'adapters/detect.md')));
+   assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
   assert.ok(fs.existsSync(path.join(cwd, 'adapters/generic.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/spec-kit.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/openspec.md')));
@@ -127,6 +175,31 @@ test('--yes non-interactive flags install without stdin and respect target arg',
   assert.ok(fs.existsSync(path.join(cwd, 'adapters/openspec.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/spec-kit.md')));
   assert.equal(fs.readFileSync(path.join(cwd, '.architecture-guard/selected-adapter'), 'utf8').trim(), 'openspec');
+});
+
+test('governed delivery installs the adapter-driven orchestration command', () => {
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
+  runArgs(['init', '--yes', '--agent', 'opencode', '--framework', 'spec-kit', '--commands', 'governed-delivery'], cwd);
+
+  const command = fs.readFileSync(path.join(cwd, '.opencode/commands/ag-governed-delivery.md'), 'utf8');
+   assert.match(command, /adapters\/resolve\.md/);
+   assert.doesNotMatch(command, /adapters\/detect\.md/);
+  assert.match(command, /adapter_command:list-specs/);
+  assert.doesNotMatch(command, /If OpenSpec is detected.*openspec new change/s);
+});
+
+test('installer never falls back to legacy Spec Kit prompts', () => {
+  const prompt = path.join(__dirname, '..', 'orchestration', 'governed-delivery.md');
+  const moved = `${prompt}.test-backup`;
+  fs.renameSync(prompt, moved);
+  try {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
+    const result = spawnSync(process.execPath, [installer, 'init', '--yes', '--agent', 'opencode', '--framework', 'spec-kit', '--commands', 'governed-delivery'], { cwd, encoding: 'utf8' });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Canonical orchestration prompt not found/);
+  } finally {
+    fs.renameSync(moved, prompt);
+  }
 });
 
 test('init accepts target directory positional argument', () => {

--- a/orchestration/apply.md
+++ b/orchestration/apply.md
@@ -6,9 +6,9 @@ description: Apply approved architecture refactors by updating plan and task art
 
 Execute this workflow through `{adapter_command:architecture-apply}`; the token is the adapter-selected capability and must not be replaced with a package-specific executable name.
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter. Resolve the concrete paths for each available artifact before classifying findings.
 
 ## Ponytail Core Contract
 
@@ -56,17 +56,20 @@ Review any available:
 
 ## Finding Partitioning
 
-Before executing edits, `ag-apply` partitions all review findings into two distinct groups based on their `Target:` field:
+Before executing edits, `ag-apply` partitions all review findings into two distinct groups by comparing each `Target:` path with the concrete paths resolved by the active adapter, never by basename alone:
 
-1. **Plan/Tasks Group**: Findings targeting the adapter-resolved planning artifact (`plan.md` for SpecKit, `design.md` for OpenSpec/generic projects that use that name) or `tasks.md`.
-2. **Upstream Group**: Findings targeting `proposal.md` or `spec.md`.
+1. **Plan/Tasks Group**: Findings targeting the adapter-resolved planning, task, task-breakdown, or checklist paths.
+2. **Upstream Group**: Findings targeting adapter-resolved proposal or specification paths.
 
 For multi-artifact findings, resolution is performed in authoritative order (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`), fixing the authoritative artifact first and propagating downstream.
 
 ## Apply Procedure
 
+### Step 0: Confirm Writes
+Present the grouped findings, concrete target paths, delegation targets, and intended edits. Ask for explicit confirmation before any repository or Flash-Mem write. If confirmation is declined, perform no writes and return all findings as `Declined`.
+
 ### Step 1: Direct Apply for Plan/Tasks Group
-1. Process all findings in the **Plan/Tasks Group** directly.
+1. After confirmation, process all findings in the **Plan/Tasks Group** directly.
 2. Preserve feature intent and implementation scope.
 3. Add or refine task entries in `tasks.md` for refactors that are safe to schedule.
 4. Reorder tasks when architectural dependencies matter.
@@ -76,11 +79,10 @@ For multi-artifact findings, resolution is performed in authoritative order (`sp
 8. If an approved Constitution Update Proposal exists, reflect it as explicit follow-up work without auto-changing the Constitution itself.
 9. When a refactor removes duplication, update the plan or tasks so the shared implementation remains the single source of truth and all callers are adjusted to use it.
 
-### Step 2: Confirmation for Upstream Group
+### Step 2: Upstream Group Confirmation
 If the **Upstream Group** contains findings:
-1. Present a grouped summary table of upstream findings organized by target artifact (`proposal.md`, `spec.md`).
-2. Prompt the user for confirmation: `"Proceed with upstream artifact fixes? [Y/n]"`
-3. If the user declines/rejects, mark all upstream findings as `skipped` in the final report and exit early.
+1. Include its adapter-resolved targets and delegation plan in Step 0 confirmation; request separate confirmation only if the delegation scope changes later.
+2. If the user declines upstream fixes, mark those findings as `Declined` while continuing any separately approved direct edits.
 
 ### Step 3: Upstream Delegation / Fallback Execution
 Upon user confirmation for the **Upstream Group**:
@@ -104,17 +106,20 @@ Return a unified summary report covering both direct edits and delegated upstrea
 # Architecture Apply Summary
 
 ## Direct Edits (Plan / Tasks)
-- **Status**: [Applied / Skipped / None Needed]
+- **Status**: [Applied / Partially Applied / Declined / None Needed]
 - **Modified Artifacts**: [e.g. design.md, tasks.md]
 - **Applied Findings**: [List of applied plan/tasks findings]
 
 ## Delegated Upstream Edits (Proposal / Spec)
-- **Status**: [Applied / Delegated / Skipped by User / No Upstream Findings]
+- **Status**: [Applied / Delegated / Partially Applied / Declined / No Upstream Findings]
 - **Delegation Target**: [Native capability name or AG-Native Fallback]
 - **Upstream Findings**:
   | ID | Target | Finding | Status |
   |:---|:---|:---|:---|
-  | V1 | `spec.md` | ... | Applied / Skipped |
+  | V1 | [adapter-resolved path] | ... | Applied / Delegated / Failed / Declined |
+
+## Unapplied Findings
+- [Finding ID, status (`Failed` or `Declined`), reason, and safe next action]
 
 ## Next Step
 - [e.g. Continue to implementation or run verification]

--- a/orchestration/consolidate-specs.md
+++ b/orchestration/consolidate-specs.md
@@ -4,9 +4,9 @@ description: Generate a compact, non-authoritative local fallback index from fea
 
 # Consolidate Specs Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -24,6 +24,10 @@ Provide the adapter's compact offline fallback for Budgeted Architecture Context
 4. Read each source only far enough to extract its title or one-line purpose, requirement and acceptance-criteria identifiers, shared invariants, cross-feature dependencies, and explicit conflicts. Acceptance-criteria bodies remain in the source spec.
 5. Deduplicate only statements that are clearly identical. Keep similar statements separate. Never resolve conflicts or ambiguity silently.
 6. Write the complete generated artifact in one operation with the structure below. Keep feature entries to one line plus identifiers and provenance so the fallback does not become another full specification.
+
+## User Interaction and Result
+
+In Generic workflow mode, ask the user for source specification paths and the desired fallback output path when the adapter cannot resolve them. Before writing or replacing a fallback, show the resolved output path and request explicit confirmation. A decline or unsupported consolidation returns the available adapter-native index or source manifest without writing.
 
 ## Required Output
 
@@ -54,7 +58,11 @@ Provide the adapter's compact offline fallback for Budgeted Architecture Context
 
 ## Completion Report
 
-Report the output path, source count, conflicts found, excluded sources, and whether regeneration was complete. Do not claim exact token savings; those require representative benchmark runs.
+Report status (`Generated`, `Declined`, `Unsupported`, `No Sources`, or `Partial`), output path, source count, conflicts found, excluded or unreadable sources, and whether regeneration was complete. Do not claim exact token savings; those require representative benchmark runs.
+
+## Next-Step Handoff
+
+Return the adapter-resolved fallback path when generated, or the returned index/manifest otherwise, as the context input for the next review or planning command. Preserve unresolved conflicts verbatim so the receiving workflow can request a decision rather than treating the fallback as authoritative.
 
 ## Backward Compatibility
 

--- a/orchestration/governed-archive.md
+++ b/orchestration/governed-archive.md
@@ -4,9 +4,9 @@ description: Verify, then archive a completed feature with explicit approval for
 
 # Governed Archive Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
 
 ## Ponytail Core Contract
 
@@ -19,10 +19,13 @@ Verifies, then finalizes a completed feature. Changelog, memory, Git, and worksp
 ## Orchestration Flow
 
 ### Step 1 — Verification and SDD Framework Archival Execution
-- Determine the active framework via `adapters/detect.md`.
+- Determine the active framework via `adapters/resolve.md`.
 - **All frameworks**: Trigger `{adapter_command:verify}` first and stop if verification fails or has unresolved blocking findings.
 - **If OpenSpec**: After verification and explicit approval, trigger `{adapter_command:archive}`; ask for the change name and archive destination if either is ambiguous.
-- **If SpecKit**: After verification and explicit approval, retain the active feature artifacts in their native `specs/<feature>/` directory and incrementally update `specs/system_context.md`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
+- **If SpecKit**: After verification and explicit approval, execute the adapter's retain-in-place archive behavior: keep the active feature artifacts in `{adapter_path:spec}`'s feature directory and incrementally update `{adapter_path:fallback-spec-index}`. Report index update failures as non-blocking warnings; do not move the feature artifacts.
+- Before any write, inspect uncommitted changes and report files the archive would touch. Never discard, stage, commit, or overwrite unrelated changes.
+- Preflight every destination for collisions. Do not overwrite or merge an existing archive/index entry without explicit approval and a stated overwrite strategy.
+- Treat archive, index/spec sync, changelog, memory, Git, and cleanup as separate operations. Stop dependent operations after a failure, preserve completed results, and report `Partial` rather than attempting an unsafe rollback.
 
 ### Step 2 — Automated Changelog Update
 Parse the archived feature purpose and requirements into a proposed changelog entry. Ask for explicit approval before appending it to CHANGELOG.md or RELEASE_NOTES.md; if neither file exists, report that and do not create one silently.
@@ -40,7 +43,7 @@ Prompt the user to execute final Git operations:
 Prepare semantic commit messages and PR descriptions from the SDD artifacts, but execute Git operations only after the user selects an action and confirms the target branch and files.
 
 ### Step 5 — Workspace Cleanup
-If Git operations were successful, offer workspace cleanup as a separate confirmation. Never check out another branch or delete a feature branch without explicit approval.
+If Git operations were successful, offer workspace cleanup as a separate confirmation. Show exactly what will be removed, refuse cleanup while affected files have uncommitted changes, and verify archive/index results before deletion. Never check out another branch or delete a feature branch without explicit approval.
 
 ## Output Structure
 
@@ -51,18 +54,19 @@ The command MUST return:
 
 ## Archival Status
 - **Framework**: [OpenSpec / SpecKit / etc.]
-- **Status**: [Success / Failed]
-- **Synced/Consolidated**: [Yes / No]
+- **Status**: [Success / Partial / Blocked / Failed / Retained In Place]
+- **Synced/Consolidated**: [Success / Partial / Skipped / Failed]
+- **Collision/Overwrite**: [None / Approval Required / Approved strategy]
 
 ## Changelog
-- **Status**: [Appended / Skipped]
+- **Status**: [Appended / Skipped / Failed]
 
 ## Memory Context
-- **Status**: [Extracted / Skipped / Unavailable]
+- **Status**: [Extracted / Skipped / Unavailable / Failed]
 
 ## Git Operations
-- **Action Taken**: [Commit / Push / PR / None]
+- **Action Taken**: [Commit / Push / PR / None / Failed]
 
 ## Workspace
-- **Status**: [Cleaned / Retained]
+- **Status**: [Cleaned / Retained / Blocked by uncommitted changes / Failed]
 ```

--- a/orchestration/governed-delivery-team.md
+++ b/orchestration/governed-delivery-team.md
@@ -4,9 +4,9 @@ description: Run team delivery with stakeholder approval of the User Story befor
 
 # Governed Team Delivery Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -31,6 +31,10 @@ Produce an approved User Story and an implementation-ready `tasks.md` from an ac
 5. Advisory findings remain non-blocking, while P0 findings always stop progression; security findings block only when governing policy assigns blocking severity.
 6. A rerun resumes safely instead of recreating valid artifacts.
 
+## Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch, change container, User Story, plan, and task artifacts together with all planned creation, status, linkage, generation, repair, and reconciliation operations. Obtain explicit user approval, then allow routine writes already previewed within this team-delivery phase scope without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ## Mandatory Branch Preflight
 
 Before creating, planning, or modifying any active change:
@@ -46,14 +50,16 @@ Before creating, planning, or modifying any active change:
 ## Phase 1 — Detect the Active Feature and Integrations
 
 1. Resolve the active work from the user's explicit path, adapter artifact paths, current branch metadata when supported, or one unambiguous result from `{adapter_command:list-specs}`, in that order.
-2. If no active feature directories exist (ignoring archives like `openspec/changes/archive/`), automatically derive a kebab-case name from the user's goal and create the new feature directory using the active SDD tool's workflow.
+2. If no active feature directories exist (ignoring archives like `openspec/changes/archive/`), automatically derive a kebab-case name from the user's goal and execute `{adapter_command:create-change}` before creating specification artifacts.
 3. Do not guess when multiple active feature directories are plausible. Ask the user to identify the feature.
 4. Detect `flash-mem` as an MCP service. Do not look for it in `{adapter_path:extensions}`.
-5. Detect Security Review from the adapter when it declares a supported extensions artifact; otherwise use host capability detection. Accept `security-review` as the canonical extension id and `spec-kit-security-review` as a compatibility alias.
+5. Detect Security Review as an independent host capability. It is not an SDD tool feature or extension; detect it from host registrations and never read `{adapter_path:extensions}` for it.
 6. Read constitution files directly when present because they may be ignored by repository search:
    - `{adapter_path:constitution}`
    - `{adapter_path:arch-constitution}`
-   - `{adapter_path:security-constitution}`
+    - `{adapter_path:security-constitution}`
+   Missing optional split constitutions fall back to applicable governance/context sections in `{adapter_path:constitution}`; report when only generic Architecture Guard rules are available.
+7. Load `{adapter_path:governance-config}` and `{adapter_path:hygiene-rules}` when present and apply configured exclusions and effective severity at plan and task gates.
 
 ## Phase 2 — Mandatory Memory Preflight When Available
 
@@ -81,11 +87,11 @@ Before engineering planning begins, generate a business-oriented User Story repr
 3. Ensure the User Story is understandable by technical and non-technical stakeholders.
 4. Persist the generated User Story as `<feature-name>.md` in the `<root>/user-stories/` directory with status `draft`.
 5. Present it for stakeholder review and stop before engineering planning until the user explicitly accepts it. Record the result as `approved` in the file.
-6. Once the User Story is approved, check for the presence of `.architecture-guard/sync.yml`. If it exists:
+6. Once the User Story is approved, check for `.architecture-guard/sync.yml`. External synchronization is a separate side effect and requires explicit approval of the resolved provider, repository/project, and target before the first push:
    - Run `npx tsx src/cli/validate-sync-config.ts` to strictly validate the configuration.
-   - If the configuration is valid and `enabled: true`, read the User Story content and push it to the configured provider (e.g., via your `github-mcp-server` to create an issue).
-   - Record the resulting issue ID or URL in `.architecture-guard/sync_status.json` (e.g., `{ "status": "success", "issue_url": "..." }`).
-   - If the push fails, write `{ "status": "failed" }` to `.architecture-guard/sync_status.json` and output a non-blocking warning. Do NOT stop the delivery workflow.
+   - If valid, enabled, and approved, use the recorded external ID/URL for this story when present and update that item instead of creating a duplicate. Otherwise create one item and persist its provider, target, ID/URL, story path, and content fingerprint in `.architecture-guard/sync_status.json`.
+   - Skip a push when the same target and content fingerprint already succeeded.
+   - On validation, approval, or provider failure, do not create/update an external item. Record `disabled`, `approval-required`, or `failed` with the target and error; warn without blocking local delivery. Never report success without a confirmed external ID/URL.
 7. If a previously approved User Story has been modified after engineering artifacts were generated, mark it `review-required`, warn the user, and require re-approval before proceeding.
 
 ## Phase 4 — Inspect Resume State
@@ -113,20 +119,22 @@ Do not use timestamps as the only evidence of material staleness. Compare artifa
 
 Before technical planning can occur, the feature must be formally proposed and specified according to the active SDD tool.
 1. Check if the adapter requires a proposal (e.g., `proposal.md` or `specs/`).
-2. If missing, you MUST require the execution of `ag-governed-spec` to correctly generate the SDD-specific specification artifacts before allowing the Plan Gate to open.
+2. If missing, you MUST execute `ag-governed-spec` for the active feature and stop the Plan Gate if governed specification does not complete successfully.
 
 ## Phase 5 — Plan Gate
 
 If the plan is `missing` or `stale`, run `ag-governed-plan` with the active feature context.
-- **Linkage metadata**: When generating the new technical plan (the technical design artifact, `design.md`, or `proposal.md`), inject the YAML frontmatter `Story: ../../../user-stories/<selected-story>.md` to establish the explicit link between the technical change and the business epic.
 
 If the plan is `review-required`, reuse it and run the applicable security plan review plus the adapter-registered violation-detection capability. Do not regenerate a plan merely because review is needed.
+
+- **Linkage metadata for every plan state**: Resolve the actual plan path and selected story path, then validate `Story:` against their normalized relative path (or an absolute path when no relative representation is possible). Add or correct stale linkage only after showing the change and receiving approval. Never assume a fixed directory depth.
 
 - Continue automatically when there are no blocking findings.
 - Record advisory architecture drift without stopping.
 - Stop before task generation for unresolved P0 findings or security findings that governing policy marks blocking. P0 cannot be overridden by a simple proceed prompt.
 - Stop when resolution requires a material product or architecture choice.
 - When a safe correction is already authorized, repair the plan, rerun affected reviews, and continue.
+- Run plan-scope hygiene checks and block only findings whose effective configured severity is failing.
 
 The plan does not need to be perfect. It must be sufficiently stable and free of unresolved blocking findings.
 
@@ -143,6 +151,7 @@ The governed task phase must:
 3. Convert confirmed architecture findings into explicit work through `{adapter_command:refactor-generator}`.
 4. Run `{adapter_command:analyze}` against the complete plan and task set.
 5. Keep implementation, security, migration, and refactor work explicit.
+6. Run task-scope hygiene checks with the same exclusions and effective severity policy.
 
 If analysis exposes a plan defect, mark the plan and tasks stale, return to the Plan Gate, and propagate the accepted correction back into tasks.
 
@@ -150,9 +159,9 @@ If analysis exposes a plan defect, mark the plan and tasks stale, return to the 
 
 When Flash-Mem is available:
 
-1. Capture changed durable artifacts with `capture_artifact_memory` using the appropriate source type.
-2. Add or update durable memory only for validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns.
-3. Do not store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
+1. Propose artifact captures and durable-memory entries, showing their sources and content summary.
+2. Execute `capture_artifact_memory`, `add_memory`, or `update_memory` only after explicit user approval.
+3. Store only validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns; never store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
 
 ## Output
 

--- a/orchestration/governed-delivery.md
+++ b/orchestration/governed-delivery.md
@@ -4,9 +4,9 @@ description: Resume governed delivery from an active specification through plan 
 
 # Governed Delivery Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -30,6 +30,10 @@ Produce an implementation-ready `tasks.md` from an accepted technical plan while
 4. Advisory findings remain non-blocking, while P0 findings always stop progression; security findings block only when governing policy assigns blocking severity.
 5. A rerun resumes safely instead of recreating valid artifacts.
 
+## Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch, change container, specification, plan, and task artifacts together with all planned creation, generation, repair, and reconciliation operations. Obtain explicit user approval, then allow routine writes already previewed within this delivery phase scope without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ## Mandatory Branch Preflight
 
 Before creating, planning, or modifying any active change:
@@ -45,14 +49,17 @@ Before creating, planning, or modifying any active change:
 ## Phase 1 — Detect the Active Feature and Integrations
 
 1. Resolve the active work from the user's explicit path, adapter artifact paths, current branch metadata when supported, or one unambiguous result from `{adapter_command:list-specs}`, in that order.
-2. If no active feature directories exist (ignoring archives like `openspec/changes/archive/`), automatically derive a kebab-case name from the user's goal and create the new feature directory using the active SDD tool's workflow.
-3. Do not guess when multiple active feature directories are plausible. Ask the user to identify the feature.
-4. Detect `flash-mem` as an MCP service. Do not look for it in `{adapter_path:extensions}`.
-5. Detect Security Review from the adapter when it declares a supported extensions artifact; otherwise use host capability detection. Accept `security-review` as the canonical extension id and `spec-kit-security-review` as a compatibility alias.
-6. Read constitution files directly when present because they may be ignored by repository search:
+2. If no active feature directories exist (ignoring archives like `openspec/changes/archive/`), automatically derive a kebab-case name from the user's goal, execute `{adapter_command:create-change}`, then execute `{adapter_command:create-spec}` for that new active work. Stop before planning if either step fails or the resulting specification is empty.
+3. If an existing active feature is resolved but its specification is missing or empty, execute `{adapter_command:create-spec}` for that active work. Stop before planning if the command fails or the resulting specification remains empty.
+4. Do not guess when multiple active feature directories are plausible. Ask the user to identify the feature.
+5. Detect `flash-mem` as an MCP service. Do not look for it in `{adapter_path:extensions}`.
+6. Detect Security Review as an independent host capability. It is not an SDD tool feature or extension; detect it from host registrations and never read `{adapter_path:extensions}` for it.
+7. Read constitution files directly when present because they may be ignored by repository search:
    - `{adapter_path:constitution}`
    - `{adapter_path:arch-constitution}`
-   - `{adapter_path:security-constitution}`
+    - `{adapter_path:security-constitution}`
+   Missing optional split constitutions are not errors: fall back to the governance/context sections in `{adapter_path:constitution}`. If no applicable constitution exists, continue with generic Architecture Guard rules and report the degraded state.
+8. Load `{adapter_path:governance-config}` and `{adapter_path:hygiene-rules}` when present. Apply configured exclusions and severity policy at the plan and task gates; missing optional hygiene configuration is non-blocking and must be reported.
 
 ## Phase 2 — Mandatory Memory Preflight When Available
 
@@ -95,6 +102,7 @@ If the plan is `review-required`, reuse it and run the applicable security plan 
 - Stop before task generation for unresolved P0 findings or security findings that governing policy marks blocking. P0 cannot be overridden by a simple proceed prompt.
 - Stop when resolution requires a material product or architecture choice.
 - When a safe correction is already authorized, repair the plan, rerun affected reviews, and continue.
+- Run plan-scope repository hygiene checks. Block only findings whose effective severity is configured to fail; report all others as advisory.
 
 The plan does not need to be perfect. It must be sufficiently stable and free of unresolved blocking findings.
 
@@ -111,6 +119,7 @@ The governed task phase must:
 3. Convert confirmed architecture findings into explicit work through `{adapter_command:refactor-generator}`.
 4. Run `{adapter_command:analyze}` against the complete plan and task set.
 5. Keep implementation, security, migration, and refactor work explicit.
+6. Run task-scope repository hygiene checks with the same configured severity policy.
 
 If analysis exposes a plan defect, mark the plan and tasks stale, return to the Plan Gate, and propagate the accepted correction back into tasks.
 
@@ -118,9 +127,9 @@ If analysis exposes a plan defect, mark the plan and tasks stale, return to the 
 
 When Flash-Mem is available:
 
-1. Capture changed durable artifacts with `capture_artifact_memory` using the appropriate source type.
-2. Add or update durable memory only for validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns.
-3. Do not store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
+1. Propose artifact captures and durable-memory entries, showing their sources and content summary.
+2. Execute `capture_artifact_memory`, `add_memory`, or `update_memory` only after explicit user approval.
+3. Store only validated decisions, constraints, approved exceptions, recurring violations, and reusable patterns; never store transient run status, speculative findings, secrets, or duplicate synthesis snapshots.
 
 ## Output
 

--- a/orchestration/governed-discover.md
+++ b/orchestration/governed-discover.md
@@ -4,9 +4,9 @@ description: Facilitate an architecture-aware discussion to flesh out ideas befo
 
 # Governed Discovery Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -35,20 +35,24 @@ Provide a single command that ensures:
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- `security-review` host capability
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment.
-2. If the adapter declares a supported extensions artifact, read its `installed` list for `security-review`; otherwise detect it from host registrations. If present, note it for downstream security flagging.
+2. Detect Security Review as an independent host capability, never from an SDD extensions artifact. Do not read `{adapter_path:extensions}` for it. If present, note it for downstream security flagging.
 3. If either capability is missing, degrade gracefully. Without `flash-mem`, rely on the local `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` files.
 
 ### Step 2 — Architecture Context Retrieval
 
 Retrieve the most relevant architectural context for the user's idea before starting the discussion. Use `flash-mem` first.
 
+If the user supplied no feature idea or only a title, ask for the minimum input needed to proceed: the user/problem, desired outcome, and known scope. Ask one necessary question at a time and remain read-only.
+
 ### Step 3 — Current Implementation Review (Optional)
 
 If the user's prompt suggests modifying an existing feature, analyze the current codebase for that feature to ensure the proposed ideas fit seamlessly with the existing patterns.
+
+Keep this review read-only and scan for boundary drift, duplicated business rules or orchestration (DRY risk), misplaced/generated artifacts, temporary files, and repository hygiene risks. Carry findings into the handoff as risks; do not modify the repository.
 
 ### Step 4 — Interactive Discussion Loop
 
@@ -62,7 +66,7 @@ Enter an interactive Q&A discussion with the user.
 
 If required questions remain unresolved, ask only the next necessary questions and do not produce the final handoff draft yet.
 
-If the user proposes a feature that touches authentication, authorization, PII, or data exposure, and `security-review` (or compatibility alias `spec-kit-security-review`) was detected in Step 1, flag the idea for downstream security review.
+If the user proposes a feature that touches authentication, authorization, PII, secrets, trust boundaries, or data exposure, always flag it as security-sensitive in the handoff. If the `security-review` host capability was detected in Step 1, additionally request its downstream review; otherwise retain the flag and note that external Security Review is unavailable.
 
 ### Step 4.5 — Durable Memory Proposal
 
@@ -75,7 +79,7 @@ If the discussion surfaced new architectural decisions, rejected alternatives, o
 Once you and the user are aligned on the feature details and any blocking/P0 conflicts are resolved:
 1. Conclude the discussion.
 2. Generate a structured **Discovery Summary Draft**.
-3. Advise the user to pass this draft to the specification phase.
+3. Hand the draft to the adapter-registered governed-spec capability as its seed input.
 
 ## Output Structure
 
@@ -100,6 +104,12 @@ When the discussion is concluded and aligned, the command MUST return:
 
 ## Open Questions
 - [Non-blocking questions that can be resolved during governed-spec]
+
+## Security-Sensitive Areas
+- [Auth, PII, secrets, trust boundaries, or data-exposure concerns; state "None identified" only after checking]
+
+## Durable Memory Proposals
+- [Proposed decision/constraint/lesson, rationale, and intended Flash-Mem type; or "None"]
 
 ## Recommended Next Step
 To proceed to implementation and avoid a "Feature: Not selected" error, you must initialize the feature using the active SDD tool's workflow (e.g., creating a new OpenSpec change) before running a delivery phase.
@@ -126,8 +136,8 @@ You can now run:
 - Fall back to reading `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` directly
 
 **Without Security Review**:
-- Skip security-relevant flagging in Step 4
-- Note missing security context in the Discovery Summary Draft
+- Continue identifying and flagging all security-sensitive ideas
+- Note that external Security Review is unavailable in the Discovery Summary Draft
 
 **Minimal Viable Workflow** (only Architecture Guard):
 - Read constitution files directly

--- a/orchestration/governed-implement.md
+++ b/orchestration/governed-implement.md
@@ -4,9 +4,9 @@ description: Execute implementation tasks, then review the result against availa
 
 # Governed Implement Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md`. Resolve the active adapter in this order: explicit `--adapter` override, `.architecture-guard/selected-adapter` as the authoritative persisted selection, then filesystem markers only when no persisted selection exists. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. Resolve every adapter token before continuing.
 
 ## Ponytail Core Contract
 
@@ -30,20 +30,24 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact code, test, and task artifacts together with all planned implementation, test, and task-checkbox operations. Obtain explicit user approval, then allow routine writes already previewed within this implementation phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- `security-review` host capability
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment. Do not treat it as a Spec Kit extension or look for it in `{adapter_path:extensions}`.
-2. If the adapter declares a supported extensions artifact, read its `installed` list for `security-review`; otherwise detect the capability from host registrations. Never resolve or read unsupported `{adapter_path:extensions}` or `{adapter_path:extensions-dir}` paths.
+2. Detect Security Review as an independent host capability, never from an SDD extensions artifact. Do not read `{adapter_path:extensions}` or `{adapter_path:extensions-dir}` for it.
 3. If either capability is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
-When Flash-Mem is available, use it first to gather the most relevant architectural context before implementation. Prefer summary-first context and only expand into repository files when needed.
+When Flash-Mem is available, execute both `get_project_summary` and `search_memory` scoped to the active feature, affected files, architecture boundaries, security-sensitive areas, prior decisions, and approved exceptions before implementation. Prefer summary-first context and load full entries only when those results are insufficient.
 
 If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
@@ -80,16 +84,18 @@ You must orchestrate the `{adapter_command:implement}` (core implementation) wor
    - Note in the Governance Summary that `{adapter_command:implement}` was unavailable and implementation was performed inline.
 3. **Write Code**: Perform the actual coding work (writing files, running tests) required by the tasks.
 4. **Sync the tasks**: You MUST update `{adapter_path:tasks}` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
+   - If implementation would expand beyond accepted spec/plan/task scope, stop and obtain explicit user approval before adding or executing that work. Record the approved expansion in the authoritative artifacts first.
 5. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
 
 The SDD-tool-native implementation behavior is defined only by `{adapter_command:implement}`.
 
 ### Step 4 — Security Review on Implementation
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `{adapter_command:security-review-branch}` to review the produced implementation against security vulnerabilities.
+IF `security-review` is available as a host capability:
+1. **Execute Review**: Dispatch the detected host Security Review capability's branch/implementation operation directly. Do not execute adapter fallback prose as a command.
 2. Check for: authorization bypass, missing validation, secret leakage, injection risk, and insecure data exposure.
 3. If security findings are architecture-relevant, classify them as `Security-Architecture Conflict` for the architecture review.
+4. Independently derive each finding's effective severity and blocking status from `{adapter_path:security-constitution}` or the applicable security policy in `{adapter_path:constitution}`. Stop for policy-designated blocking findings; advisory findings do not become blocking merely because they are security findings.
 
 ### Step 5 — Architecture Review on Implementation
 
@@ -105,7 +111,7 @@ Review implementation against:
 
 ### Step 5.5 — Blocking Decision Tree
 
-**Critical Decision Point**: Evaluate architecture findings for blocking issues.
+**Critical Decision Point**: Evaluate architecture and security findings independently for blocking issues.
 
 ```
 IF Architecture Review finds CRITICAL or HIGH violations:
@@ -119,6 +125,10 @@ IF Architecture Review finds CRITICAL or HIGH violations:
     Flag for post-merge remediation
 ELSE (no critical violations):
   Continue to Step 6
+
+IF Security Review finds a policy-designated blocking violation:
+  STOP implementation completion
+  Surface the security remediation tasks independently of architecture findings
 ```
 
 **Rationale**: This ensures architectural integrity while preserving delivery momentum for non-blocking issues.
@@ -127,16 +137,20 @@ ELSE (no critical violations):
 
 IF architecture violations exist:
 1. Run `{adapter_command:refactor-generator}`.
-2. Generate non-blocking refactor, migration, or correction tasks.
+2. Generate blocking remediation tasks for unresolved P0 or policy-designated blocking findings; generate advisory refactor, migration, or correction tasks for all other findings.
 3. Skip performance refactors unless explicitly requested.
 
-### Step 7 — Proactive Durable Memory Preservation
+### Step 7 — Mandatory Verification Gate
+
+Run `{adapter_command:verify}` after implementation and reviews. Do not mark the workflow complete or ready to merge until verification passes with no unresolved blocking findings; if unavailable as a registered capability, execute the Architecture Guard verification workflow inline.
+
+### Step 8 — Proactive Durable Memory Preservation
 
 If the implementation review or security audit identified new architectural patterns, critical decisions, or repeatable lessons:
 1. **Approval Required**: Propose validated durable-memory entries and execute the capture flow only after explicit user approval.
 2. **Standard**: Do not silently write memory outside the approved capture flow.
 
-### Step 8 — Implementation Governance Summary
+### Step 9 — Implementation Governance Summary
 
 Produce a final `Governed Implementation Summary`.
 
@@ -145,7 +159,7 @@ Produce a final `Governed Implementation Summary`.
 **Without Flash-Mem MCP**:
 - Skip Step 2 (Flash-Mem MCP Context Retrieval)
 - Continue to `{adapter_command:implement}` directly
-- Assume no historical implementation constraints beyond Constitution
+- Use active spec, plan, tasks, repository evidence, and any present constitutions as current authority; report that historical memory context was unavailable rather than assuming no historical constraints exist
 
 **Without Security Review**:
 - Skip Step 4 (Security Review on Implementation)
@@ -166,6 +180,7 @@ Produce a final `Governed Implementation Summary`.
 - Execute implementation through `{adapter_command:implement}` or its inline fallback
 - Run architecture review on output
 - Generate non-blocking refactor tasks
+- Pass mandatory verification
 - Produce summary
 
 ## Output Structure
@@ -182,7 +197,7 @@ The command MUST return:
 ## Security Review
 - **Findings**: [List of security vulnerabilities found]
 - **Constraints**: [Trust boundaries validated]
-- **Blocking Concerns**: [Any P0 security risks]
+- **Blocking Concerns**: [Policy-designated blocking security findings]
 
 ## Architecture Review
 - **Violations**: [Drift findings or Security-Architecture Conflicts]
@@ -197,7 +212,7 @@ The command MUST return:
 - [e.g., Revise implementation to address Security Conflict]
 - [e.g., Run `{adapter_command:architecture-apply}`]
 - **Durable Memory Preservation**: (Proactively triggered) Review the proposed memory entries below.
-- **Verification Gate**: Run the adapter's registered architecture-verify capability to ensure all tasks are delivered and requirements are met.
+- **Verification Gate**: [Passed / Blocked / Unavailable fallback executed]
 ```
 
 ## Security + Architecture Conflict Handling

--- a/orchestration/governed-plan.md
+++ b/orchestration/governed-plan.md
@@ -4,9 +4,9 @@ description: Generate and validate a technical plan with optional Flash-Mem cont
 
 # Governed Plan Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -30,12 +30,20 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact target plan and constraint artifacts together with all planned generation, correction, and constraint-write operations. Obtain explicit user approval, then allow routine writes already previewed within this planning phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
+### Required Active Inputs
+
+Require an active `{adapter_path:spec}` and applicable `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, and `{adapter_path:security-constitution}` inputs. For optional split layouts, embedded rules in `{adapter_path:constitution}` satisfy the split input. Ask for Generic paths when unresolved. If the active specification, governance rules, or architecture rules are missing, stop and direct the user to governed-spec or init as appropriate; if security rules are missing, report the gap and obtain explicit confirmation before continuing with baseline security validation.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
 - Memory MD local CLI
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- `security-review` host capability
 
 **Detection Logic**:
 1. Treat `flash-mem` as available only when its MCP tools are exposed by the host.
@@ -52,13 +60,12 @@ If Flash-Mem is unavailable or the context is insufficient, continue with the re
 When Flash-Mem MCP is unavailable but the Memory MD CLI detected in Step 1 is present, use that CLI for supported local context preparation, search, or synthesis before falling back to repository artifacts. Inspect its help once when command syntax is needed; do not search for an MCP wrapper or a global/shared publication tool.
 
 **[OPTIONAL SUB-AGENT DELEGATION]**
-* **Capability Gate:** First confirm that `{adapter_command:subagent-synthesize}` is registered and callable. If it is unavailable, execute inline regardless of size and report the degraded path.
+* **Capability Gate:** Detect a host synthesis/delegation capability independently of the adapter command map. If unavailable, execute inline regardless of size and report the degraded path.
 * **Trigger Condition:** When the capability is available, you **MUST** delegate memory retrieval and synthesis if:
   - The Flash-Mem index contains $\ge 20$ memory documents.
   - OR the project repository contains $\ge 15$ active ADRs/docs.
   - Otherwise, you **MUST** execute inline.
-* **Execution Syntax:** Call the memory synthesis sub-agent via:
-  `{adapter_command:subagent-synthesize} --context=architecture-boundaries`
+* **Execution:** Invoke the host capability directly with the handoff below and architecture-boundary context. Do not append flags to `{adapter_command:subagent-synthesize}` or execute adapter fallback prose.
 * **Strict Handoff Template:** Format the sub-agent prompt exactly like this:
   ```yaml
   Task: Retrieve and synthesize relevant architecture constraints and ADRs.
@@ -90,8 +97,8 @@ You must orchestrate the `{adapter_command:create-plan}` workflow directly.
 
 ### Step 4 — Security Review (Optional)
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `{adapter_command:security-review-plan}` to review the plan and save `{adapter_path:security-constraints}`.
+IF `security-review` is available as a host capability:
+1. **Execute Review**: Invoke the host Security Review capability directly with `{adapter_path:plan}`, the active spec, and applicable constitutions; save its actionable output to `{adapter_path:security-constraints}` only when that write is approved.
 2. Focus on:
     - Trust boundaries and authorization assumptions.
     - Data isolation and validation risks.
@@ -110,7 +117,7 @@ Inputs to consider:
 - Flash-Mem context (if available).
 - `security-constraints.md` (if available).
 
-Detect any `Security-Architecture Conflict` or architectural drift.
+Detect any `Security-Architecture Conflict` or architectural drift. Explicitly validate one canonical owner for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration (DRY), plus artifact locations, temporary/generated files, and repository cleanliness against `{adapter_path:hygiene-rules}`.
 
 ### Step 6 — Proactive Durable Memory Preservation
 
@@ -177,6 +184,7 @@ The command MUST return:
 
 - **Framework-Agnostic**: Do not assume specific framework conventions unless provided via a preset.
 - **Non-Blocking**: Findings should be advisory by default unless they violate a P0 rule in the Constitution.
+- **Independent Security Policy**: Preserve Security Review severity and blocking decisions independently from architecture severity and P0 handling; architecture defaults must not downgrade or unblock Security Review findings.
 - **Incremental**: Prefer suggestions for incremental migration over full rewrites.
 - **Decoupled**: Do not tightly couple the logic to the internals of other extensions; rely on documented context and repository artifacts.
 

--- a/orchestration/governed-spec.md
+++ b/orchestration/governed-spec.md
@@ -4,9 +4,9 @@ description: Orchestrate governed specification with memory, framework-native sp
 
 # Governed Specification Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -31,27 +31,35 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact branch and target artifacts for change creation, specification generation, clarification updates, and any fallback-index refresh, together with the planned operations. Obtain explicit user approval, then allow routine writes already previewed within this specification phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- `security-review` host capability
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment.
-2. If the adapter declares a supported extensions artifact, read its `installed` list for `security-review`; otherwise detect the capability from host registrations without resolving or reading `{adapter_path:extensions}`.
+2. Detect Security Review as an independent host capability, never from an SDD extensions artifact. Do not read `{adapter_path:extensions}` for it.
 3. If either capability is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
 
 When Flash-Mem is available, use it first to gather the most relevant architectural context before generating the specification.
 
+### Step 2.5 — Required Governance Inputs
+
+Resolve `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, and `{adapter_path:security-constitution}`. For Generic mode, ask the user for every unresolved required path and the destination specification path before continuing; resolve that destination as `{adapter_path:spec}` and never guess or write until it is supplied. For adapters with optional split files, rules embedded in `{adapter_path:constitution}` satisfy the corresponding input. If governance or architecture rules are missing entirely, stop and direct the user to the adapter-registered init capability. If security rules are missing, report the gap and require explicit user confirmation before continuing with baseline security checks and optional host Security Review.
+
 ### Step 3 — Branch Management
 
 Before generating the specification, you MUST ensure work happens on a feature branch.
 1. Check the current git branch.
-2. If on `main`, `master`, `dev*` (e.g., `dev`, `develop`, `development`), or `staging`, ask the user if they want to create a new branch for this feature.
-3. If they approve, create the branch using available tools before proceeding.
+2. If on `main`, `master`, `dev*` (e.g., `dev`, `develop`, `development`), or `staging`, require creation or selection of a feature branch before any specification write.
+3. Ask approval before branch creation, create it using available tools, and stop if creation or checkout fails or approval is declined. If the adapter requires stricter branch handling, enforce it.
 
 ### Step 4 — Create or Select the Change Container
 
@@ -72,24 +80,27 @@ You must orchestrate the `{adapter_command:create-spec}` workflow directly.
 
 You must orchestrate the `{adapter_command:clarify-spec}` workflow directly.
 
-1. **Execute Clarify**: Run `{adapter_command:clarify-spec}` to resolve ambiguities in the newly generated `spec.md`.
+1. **Execute Clarify**: Run `{adapter_command:clarify-spec}` to resolve ambiguities in the newly generated `{adapter_path:spec}`.
 2. Ensure clarification considers `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}`.
 
 ### Step 7 — Architecture Validation
 
 Run an inline architecture validation against the clarified specification.
 Inputs to consider:
-- The generated `spec.md`.
+- The generated `{adapter_path:spec}`.
 - `{adapter_path:arch-constitution}`.
 - Flash-Mem context (if available).
 
-Detect any `Security-Architecture Conflict` or architectural drift present in the specification's assumptions or boundaries.
+Detect any `Security-Architecture Conflict` or architectural drift present in the specification's assumptions or boundaries. Explicitly validate that repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration have one intended owner (DRY), and that proposed paths, generated artifacts, temporary files, and repository placement comply with hygiene rules from `{adapter_path:hygiene-rules}`.
+
+If the host exposes Security Review and the specification is security-sensitive or security rules are missing, invoke that host capability directly with `{adapter_path:spec}` and applicable constitutions. Do not execute adapter fallback prose as a command. Record its findings separately and feed architecture-boundary conflicts into this validation.
 
 ### Step 8 — Proactive Durable Memory Preservation
 
 If the specification process or architecture validation identified new architectural patterns or critical decisions:
-1. **Proactive Execution**: You **MUST automatically execute** the durable-memory capture flow.
-2. **Standard**: Do not silently write memory outside the capture flow; let the formal capture flow propose entries and handle user approval.
+1. **Proactive Proposal**: You **MUST automatically launch** the durable-memory capture flow in proposal-only mode.
+2. **Approval Required**: Show the proposed entries and obtain explicit user approval before invoking any memory write tool.
+3. **Standard**: Do not silently write memory inside or outside the capture flow.
 
 ### Step 9 — Generate Governance Summary
 

--- a/orchestration/governed-tasks.md
+++ b/orchestration/governed-tasks.md
@@ -4,9 +4,9 @@ description: Generate or reconcile implementation tasks, then analyze security, 
 
 # Governed Tasks Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -32,15 +32,23 @@ Provide a single command that ensures:
 
 ## Orchestration Flow
 
+### Write Approval Gate
+
+Before the first mutation, resolve and preview the exact target task and constraint artifacts together with all planned task-generation, reconciliation, refactor, analysis-fix, and constraint-write operations. Obtain explicit user approval, then allow routine writes already previewed within this task phase without per-file prompts. Newly discovered material scope or any new target path requires a new preview and renewed approval.
+
+### Required Active Inputs
+
+Require active `{adapter_path:spec}` and `{adapter_path:plan}` artifacts plus applicable `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, and `{adapter_path:security-constitution}` inputs. For optional split layouts, embedded rules in `{adapter_path:constitution}` satisfy the split input. In Generic mode, ask for every unresolved input path and the destination tasks path, resolve the latter as `{adapter_path:tasks}`, and do not write until it is supplied. If the spec, plan, governance rules, or architecture rules are missing, stop and direct the user to the corresponding governed phase or init; if security rules are missing, report the gap and obtain explicit confirmation before continuing with baseline security task validation.
+
 ### Step 1 — Detect Optional Integrations
 
 Check for the availability of:
 - `flash-mem` MCP server
-- `security-review` (or compatibility alias `spec-kit-security-review`) extension
+- `security-review` host capability
 
 **Detection Logic**:
 1. Detect `flash-mem` as an MCP-backed memory service in the current environment. Do not treat it as a Spec Kit extension or look for it in `{adapter_path:extensions}`.
-2. If the adapter declares a supported extensions artifact, read its `installed` list for `security-review`; otherwise detect the capability from host registrations. Never resolve or read unsupported `{adapter_path:extensions}` or `{adapter_path:extensions-dir}` paths.
+2. Detect Security Review as an independent host capability, never from an SDD extensions artifact. Do not read `{adapter_path:extensions}` or `{adapter_path:extensions-dir}` for it.
 3. If either capability is missing, degrade gracefully by skipping only its respective steps.
 
 ### Step 2 — Flash-Mem MCP Context Retrieval (Optional)
@@ -50,13 +58,12 @@ When Flash-Mem is available, use it first to gather the most relevant architectu
 If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
 
 **[OPTIONAL SUB-AGENT DELEGATION]**
-* **Capability Gate:** First confirm that `{adapter_command:subagent-synthesize}` is registered and callable. If it is unavailable, execute inline regardless of size and report the degraded path.
+* **Capability Gate:** Detect a host synthesis/delegation capability independently of the adapter command map. If unavailable, execute inline regardless of size and report the degraded path.
 * **Trigger Condition:** When the capability is available, you **MUST** delegate memory retrieval and synthesis if:
   - The Flash-Mem index contains $\ge 20$ memory documents.
   - OR the project repository contains $\ge 15$ active ADRs/docs.
   - Otherwise, you **MUST** execute inline.
-* **Execution Syntax:** Call the memory synthesis sub-agent via:
-  `{adapter_command:subagent-synthesize} --context=tasks-generation`
+* **Execution:** Invoke the host capability directly with the handoff below and task-generation context. Do not append flags to `{adapter_command:subagent-synthesize}` or execute adapter fallback prose.
 * **Strict Handoff Template:** Format the sub-agent prompt exactly like this:
   ```yaml
   Task: Retrieve and synthesize relevant architecture constraints and ADRs.
@@ -77,23 +84,23 @@ You must orchestrate the `{adapter_command:create-tasks}` workflow directly.
 2. **Execute Tasks**: Run `{adapter_command:create-tasks}` to generate and save `{adapter_path:tasks}`.
 
    **If `{adapter_command:create-tasks}` is not available as a registered command** (i.e., the AI agent does not recognize it as a slash command), fall back to inline task generation:
-   - Read `{adapter_path:plan}` (and `spec.md` if present).
+    - Read `{adapter_path:plan}` and `{adapter_path:spec}`.
    - Read all applicable constitution files (`{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, `{adapter_path:security-constitution}`).
    - Use Flash-Mem context and `{adapter_path:security-constraints}` if available.
    - Generate `{adapter_path:tasks}` directly, breaking down the plan into implementation-ready tasks with checkbox format. Enforce Ponytail minimalism.
    - Note in the Governance Summary that `{adapter_command:create-tasks}` was unavailable and task generation was performed inline.
 
-2. The generated tasks MUST use the Project Constitution documents and feature context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read constitution files and feature security constraints directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
-3. Prefer compact, feature-scoped task generation over broad restatements of the full memory set.
+3. The generated tasks MUST use the Project Constitution documents and feature context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read constitution files and feature security constraints directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
+4. Prefer compact, feature-scoped task generation over broad restatements of the full memory set.
 
 ### Step 4 — Security Review on Tasks
 
-IF `security-review` (or compatibility alias `spec-kit-security-review`) is available:
-1. **Execute Review**: Run `{adapter_command:security-review-tasks}` to review the task list.
+IF `security-review` is available as a host capability:
+1. **Execute Review**: Invoke the host Security Review capability directly with `{adapter_path:tasks}`, the active spec and plan, and applicable constitutions. Do not execute adapter fallback prose as a command.
 2. Check for missing tasks related to:
     - Validation, authorization, and trust boundaries.
     - Secure integration and audit/logging.
-3. Update `{adapter_path:security-constraints}` with any new findings.
+3. Propose updates to `{adapter_path:security-constraints}` for new findings, show the exact target and changes, and write them only after explicit user approval.
 
 ### Step 5 — Architecture Refactor Generation
 
@@ -112,13 +119,15 @@ It MUST convert architecture findings into:
 You must orchestrate the `{adapter_command:analyze}` workflow directly to serve as the formal analyst.
 
 1. **Execute Analyze**: Run `{adapter_command:analyze}` on the complete task list and architecture refactors.
-2. **Architecture Validation**: Detect any gaps, missing requirements, or high-severity execution risks present in the implementation plan or task list.
+2. **Architecture Validation**: Detect any gaps, missing requirements, or high-severity execution risks present in the implementation plan or task list. Explicitly verify DRY coverage for repeated business rules, approvals, validation, DTO mapping, transformations, and orchestration, plus cleanup/placement tasks required by `{adapter_path:hygiene-rules}`.
+3. **Task Identity Reconciliation**: After adding security or refactor work, ensure every task has one unique, stable sequential ID; update references without reusing or silently renumbering completed IDs.
 
 ### Step 7 — Proactive Durable Memory Preservation
 
 If the task generation or security review identified new architectural lessons or reusable patterns:
-1. **Proactive Execution**: You **MUST automatically execute** the durable-memory capture flow as the final part of this turn. Do not just recommend it; run the command.
-2. **Standard**: Do not silently write memory outside the capture flow; let the formal capture flow propose entries and handle user approval.
+1. **Proactive Proposal**: You **MUST automatically launch** the durable-memory capture flow in proposal-only mode as the final part of this turn.
+2. **Approval Required**: Show the proposed entries and obtain explicit user approval before invoking any memory write tool.
+3. **Standard**: Do not silently write memory inside or outside the capture flow.
 
 ### Step 8 — Task Governance Summary
 
@@ -186,7 +195,8 @@ The command MUST return:
 
 - **Separation**: Clearly separate implementation tasks, security tasks, and architecture refactor tasks.
 - **Precision**: Do NOT merge findings into vague task items.
-- **Non-Blocking**: Findings are advisory by default.
+- **Non-Blocking**: Findings are advisory by default; explicitly blocking/P0 findings remain blocking.
+- **Independent Security Policy**: Preserve Security Review severity and blocking decisions independently from architecture severity and P0 handling; architecture defaults must not downgrade or unblock Security Review findings.
 
 
 ## Backward Compatibility

--- a/orchestration/init-brownfield.md
+++ b/orchestration/init-brownfield.md
@@ -4,9 +4,9 @@ description: Perform brownfield-first project initialization and discovery for e
 
 # init-brownfield
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -27,7 +27,7 @@ Create a reliable current-state baseline before any architectural or delivery gu
 3. Note any current conventions, constraints, and risky areas.
 4. Capture known gaps between the current codebase and the desired governance model.
 5. Identify existing pragmatic patterns (Ponytail principles: YAGNI, standard library preference, minimal abstractions) to preserve in the constitution.
-6. Produce an initial brownfield plan instead of assuming a greenfield setup.
+6. Produce a recommendation outline for bringing the project under governance, not the canonical `{adapter_path:plan}`.
 7. Use `{adapter_command:list-specs}` to count and estimate active `{adapter_path:spec}` artifacts, excluding generated or explicitly archived artifacts.
 8. Offer Budgeted Architecture Context Retrieval when repeated historical-spec loading is likely to be material.
 
@@ -41,6 +41,7 @@ Create a reliable current-state baseline before any architectural or delivery gu
 
 ## Guidance
 
+- Before recommendations, run a read-only baseline gate covering architecture boundaries and dependency direction, security-sensitive entrypoints and trust boundaries, duplicated business rules/validation/mapping/orchestration (DRY), and repository hygiene. Report evidence, severity, and unknowns; do not mutate artifacts or code.
 - Prefer observation over assumption.
 - Treat existing code as the source of truth.
 - Keep the first pass lightweight and non-destructive.
@@ -48,6 +49,7 @@ Create a reliable current-state baseline before any architectural or delivery gu
 - Recommend targeted mode for small spec sets. For larger histories, explain that budgeted mode queries Flash-Mem first, uses `{adapter_path:fallback-spec-index}` only when supported, and never replaces active artifacts.
 - If the user wants budgeted mode, record the recommendation in the brownfield output and hand it to the adapter-registered init capability. Do not create configuration or generate `system_context.md` during this non-destructive mapping pass.
 - Do not promise token savings before representative measurement and do not write operational settings into constitution files.
+- Label the result `Brownfield Recommendation Outline`. The canonical technical plan is created later by the adapter-registered governed-plan capability after active constitutions and a specification exist.
 
 ## When to use
 

--- a/orchestration/init.md
+++ b/orchestration/init.md
@@ -2,9 +2,9 @@
 description: Initialize or refine the project governance and architecture constitutions for Architecture Guard.
 ---
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 # Purpose
 
@@ -35,7 +35,7 @@ See the README quick start for brownfield and greenfield entrypoints.
 
 After init, the usual next step is to run the applicable governance command for the active SDD tool (planning or task generation) via the orchestration flow.
 
-When Flash-Mem is available, prefer it first for retrieving prior decisions, summaries, and existing constitution context. The repository files remain the source of truth for constitution content, and the legacy `memory-hub` name is reference-only and should not be treated as the runtime backend. If Flash-Mem is unavailable or the context is incomplete, read the repository files directly and treat them as the canonical source of truth. After refining the constitutions, sync durable summaries and major decisions back into Flash-Mem.
+When Flash-Mem is available, call `get_project_summary`, then `search_memory`; prefer summaries and metadata and load full entries only as needed. The repository files remain the source of truth for constitution content, and the legacy `memory-hub` name is reference-only and should not be treated as the runtime backend. If Flash-Mem is unavailable or the context is incomplete, read the repository files directly and treat them as canonical. After refinement, use `capture_artifact_memory` for changed constitution artifacts and propose validated `add_memory` or `update_memory` entries for explicit approval. Ask permission before `update_project_summary` when a summary already exists.
 
 The goal is NOT to generate generic best practices.
 
@@ -67,7 +67,8 @@ The goal is to establish:
 - Command starts technology-agnostic
 - If preset selected: Constitution gains framework-aware guidance
 - Both layers work together: abstract principles + concrete framework patterns
-- Switching frameworks: Start over, preset vocabulary changes but core governance remains
+- Switching application frameworks: preserve accepted framework-neutral rules, re-run only affected preset questions, and explicitly approve replacement of framework-specific rules; do not start over or change the selected SDD adapter implicitly
+- Refining the current framework preset: keep unaffected accepted rules and ask only questions needed for the requested refinement
 
 ---
 
@@ -286,7 +287,22 @@ Check for:
 
 ---
 
-## If BOTH files exist
+## Existing-State Rules
+
+Treat OpenSpec's `{adapter_path:constitution}` as complete when architecture and security rules are embedded there; `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` are optional split files. If either split exists, reconcile ownership with `{adapter_path:constitution}` and remove duplication only after approval.
+
+| Existing state | Behavior |
+|---|---|
+| All three exist | Summarize, reconcile conflicts and duplication, then offer targeted refinement. |
+| Governance + architecture exist | Preserve both; offer embedded security rules or the optional security split. |
+| Governance + security exist | Preserve both; offer embedded architecture rules or the optional architecture split. |
+| Architecture + security exist | Ask for the governance artifact path/content and offer to create it; do not rewrite either split first. |
+| Governance only | Analyze embedded architecture/security rules and offer optional splits. |
+| Architecture only | Preserve it and offer governance plus security coverage. |
+| Security only | Preserve it and offer governance plus architecture coverage. |
+| None exist | Start the phased initialization interview. |
+
+## If all three files exist
 
 1. Summarize:
 
@@ -315,16 +331,17 @@ Would you like to:
 
 1. Analyze architecture-related sections.
 
-2. Detect rules that should move into:
+2. Detect architecture and security rules that could remain embedded or move into:
 
 ```text
 {adapter_path:arch-constitution}
+{adapter_path:security-constitution}
 ```
 
 3. Ask:
 
 ```text
-Would you like to split architecture rules into a dedicated architecture constitution?
+Would you like to keep these rules embedded, or split architecture and/or security rules into dedicated constitution files?
 ```
 
 ---
@@ -348,6 +365,7 @@ Determine:
 * runtime boundaries
 * application type
 * deployment shape
+* Generic adapter paths for `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, `{adapter_path:security-constitution}`, and any requested `{adapter_path:governance-config}` before generation
 
 ---
 
@@ -430,10 +448,10 @@ Are you working on this project as a solo developer, or as part of a team?
 ```
 
 If the user selects Team Development:
-1. Write `Mode: Team` into the governance rules (e.g., `openspec/config.yaml` or `.specify/memory/constitution.md`).
+1. Record `Mode: Team` for the proposed governance changes.
 2. Ask: "Which issue tracker MCP server should be used to sync User Stories? (e.g., github-mcp-server, jira, none)". Save this preference in the governance rules.
-3. Automatically scaffold a `user-stories/` directory at the project root to house global business requirements.
-4. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira). Then, automatically scaffold the `.architecture-guard/sync.yml` file configuring the chosen provider, the project/repo string, and `enabled: true`.
+3. Propose scaffolding a `user-stories/` directory at the project root and obtain explicit approval before creating it.
+4. If an issue tracker is selected (not "none"), ask for the required provider configuration (e.g., `repo` string for GitHub or `project` string for Jira). Propose `.architecture-guard/sync.yml` with the chosen provider, project/repo string, and `enabled: true`; obtain explicit approval before creating it.
 
 ---
 
@@ -903,6 +921,8 @@ DO NOT generate final documents until:
 * enough information has been collected
 * OR the user explicitly requests a draft
 
+Before creating, modifying, deleting, moving, or scaffolding any file or directory, show the exact target paths and proposed operations and obtain explicit user approval. Interviewing, detection, analysis, and previews remain read-only. This applies to `{adapter_path:draft}`, team scaffolds, Generic user-provided paths, optional OpenSpec split files, and `{adapter_path:governance-config}`.
+
 ---
 
 # Output Requirements
@@ -915,7 +935,7 @@ Generate or refine:
 
 When Budgeted Architecture Context Retrieval is selected, also generate `{adapter_path:governance-config}`. Missing configuration means targeted mode, preserving backward compatibility.
 
-If the `flash-mem` MCP server is available, you MUST run the `update_project_summary` tool to reflect any major changes in architecture, boundaries, or governance rules in the project summary. If it is unavailable, rely on the repository files directly and continue without the sync step.
+If the `flash-mem` MCP server is available, propose changed-artifact captures and durable `add_memory` or `update_memory` entries, then execute only those the user explicitly approves. For major changes in architecture, boundaries, or governance rules, propose `update_project_summary`, asking permission before any update when a summary already exists. If Flash-Mem is unavailable, rely on repository files and continue without sync.
 
 ---
 
@@ -1019,7 +1039,7 @@ The generated constitutions must reflect intentional engineering decisions.
 The init interview produces framework-specific constitution files:
 
 - **SpecKit adapter**: Writes `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, `{adapter_path:security-constitution}`
-- **OpenSpec adapter**: Updates `{adapter_path:constitution}` (config.yaml context+rules), optionally creates `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}`
+- **OpenSpec adapter**: Updates `{adapter_path:constitution}` (config context and rules); `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` remain optional splits and, when present, are reconciled with config so each rule has one canonical owner
 
 ---
 

--- a/orchestration/refactor-generator.md
+++ b/orchestration/refactor-generator.md
@@ -4,9 +4,9 @@ description: Convert architecture violations into non-blocking, structured refac
 
 # Refactor Generator Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -106,7 +106,7 @@ Suggested fixes should be concrete:
 
 ### Incremental Migration Strategy
 When generating refactor tasks based on architecture drift, you MUST avoid proposing full system rewrites. Prefer incremental, boundary-by-boundary, or module-by-module migrations.
-Output any requested phased migration strategy beside `{adapter_path:plan}` using the adapter's active work directory. Include coexistence strategies for old and new patterns.
+Return any requested phased migration strategy in the response first. Before writing it beside `{adapter_path:plan}` in the adapter's active work directory, show the target path and request explicit user approval. Write only after approval. Include coexistence strategies for old and new patterns.
 
 ## Architecture Migration Plan Structure
 
@@ -164,7 +164,7 @@ When creating the adapter-resolved architecture migration plan, use this structu
 
 ## Output Format
 
-Return only:
+Return only the task structure below. Any proposed migration artifact is included after the tasks as response content; approval and writing occur in a separate interaction.
 
 ```text
 Refactor Tasks:
@@ -198,6 +198,9 @@ Reason: The route currently owns a business decision that should live behind the
 Scope: Checkout request handler and checkout application service.
 Priority: P1
 Suggested Fix: Extract pricing decision logic into the checkout service or domain policy, keep the route responsible for validation, mapping, and delegation only.
+Consequence: Pricing behavior can diverge across entry points if the route continues to own the rule.
+Verification: Exercise every checkout entry point and confirm each delegates to the same pricing rule.
+Trade-off: The shared boundary gains one responsibility while routes become transport-only.
 ```
 
 ```text
@@ -208,6 +211,9 @@ Reason: The same tax rule appears in multiple checkout modules, which creates du
 Scope: Checkout service and any callers that currently reimplement the tax rule.
 Priority: P1
 Suggested Fix: Move tax calculation into one shared checkout service or domain helper, then have callers reuse that single implementation.
+Consequence: Tax changes can produce inconsistent totals while duplicate implementations remain.
+Verification: Compare all callers against one set of tax-rule cases and confirm they use the shared implementation.
+Trade-off: Callers depend on the shared checkout boundary instead of local calculations.
 ```
 
 ```text
@@ -218,6 +224,9 @@ Reason: Multiple handlers validate the same request shape in slightly different 
 Scope: Request boundary and the shared validation contract or helper used by those handlers.
 Priority: P1
 Suggested Fix: Move the validation rule into one shared schema, form request, or helper, then have each handler call the same boundary check.
+Consequence: Equivalent requests can be accepted or rejected differently across handlers.
+Verification: Run the same valid and invalid examples through every affected handler.
+Trade-off: Validation changes become coordinated through one shared contract.
 ```
 
 ```text
@@ -228,6 +237,9 @@ Reason: Multiple modules build the same response shape independently, which dupl
 Scope: Response mapping layer and the callers that currently construct the same DTO shape.
 Priority: P2
 Suggested Fix: Extract the mapping into one shared DTO factory, serializer, or adapter, then reuse that transformation everywhere the shape is needed.
+Consequence: Consumers can receive incompatible response shapes as independent mappings evolve.
+Verification: Assert every affected caller emits the shared DTO shape.
+Trade-off: Callers depend on one shared response transformation.
 ```
 
 ```text
@@ -238,6 +250,9 @@ Reason: The same approval or discount rule is enforced in multiple places, which
 Scope: Domain policy or application service and all call sites that currently reimplement the same rule.
 Priority: P1
 Suggested Fix: Move the policy into one shared domain service or policy object, then have every caller delegate to that single rule.
+Consequence: Approval or discount outcomes can differ by call path.
+Verification: Run the same policy cases through every call path and confirm delegation to the shared rule.
+Trade-off: Policy changes are centralized and therefore require shared-boundary review.
 ```
 
 ## Backward Compatibility

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -4,13 +4,23 @@ description: Review specification and planning artifacts against architectural r
 
 # Architecture Review Command
 
+## SDD Adapter Resolution
+
+Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+
+1. An explicit `--adapter` override, when provided.
+2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
+3. Filesystem markers only when no persisted selection exists.
+
+Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` token before reading review artifacts. Stop if the adapter is missing or any token remains unresolved.
+
 ## Ponytail Core Contract
 
 Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}` (or `templates/ponytail_core.md` in the extension source checkout) as the authoritative shared contract. Phase instructions may narrow but not weaken its safety or verification floor.
 
 ## Budgeted Context Contract
 
-Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, applicable constitutions, and relevant code evidence are authoritative. Use fallback provenance to open historical specs only for named review gaps.
+Read and apply `{adapter_path:budgeted-context-template}` (or `templates/budgeted_context.md` in the extension source checkout). Available active specification documents (the exact filenames depend on the active SDD tool), security constraints, and applicable constitutions are authoritative. Use fallback provenance to open historical specs only for named review gaps.
 
 You are running `architecture-guard`, a technology-agnostic architecture review extension designed for high-integrity governance.
 
@@ -39,7 +49,7 @@ You are running `architecture-guard`, a technology-agnostic architecture review 
 
 **Coexistence Model**:
 - Review always starts technology-agnostic
-- If preset detected in `.specify/presets/` or the Constitution: Enhance with framework vocabulary
+- If adapter-resolved preset guidance or Constitution guidance is available: Enhance with framework vocabulary
 - Violations list remains the same; explanation becomes framework-native
 - Example: "Entry boundary contamination" (agnostic) → "Controller mixing HTTP and business logic" (Laravel-aware)
 
@@ -79,10 +89,10 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 ## Semantic Modeling
 
 Before analysis, build internal representations (do not output these):
-1. **Boundary Model**: Map the expected boundaries (Entry, Application, Domain, Data, External) vs. actual directory structure.
+1. **Boundary Model**: Map the expected boundaries (Entry, Application, Domain, Data, External) to the structure proposed by the planning artifacts.
 2. **Contract Inventory**: Identify shared data shapes, API signatures, and event structures.
-3. **Task-Implementation Map**: Map `tasks.md` IDs to specific code files and check completion status.
-4. **Dependency Graph**: Map module-to-module dependencies to detect coupling or layering violations.
+3. **Task-Coverage Map**: Map task IDs to planned requirements, boundaries, and verification work.
+4. **Planned Dependency Graph**: Map proposed module dependencies to detect planned coupling or layering violations.
 
 ## Review Principles
 
@@ -94,27 +104,27 @@ Use these core principles to detect drift:
 - **Isolation**: Data access, external APIs, and infrastructure must be isolated.
 - **Consistency**: Comparable endpoints or modules must use compatible patterns.
 - **DRY / Single Source of Truth**: Repeated business rules, validation, transformations, or orchestration should be centralized once and reused instead of copied across modules.
-- **Ponytail Pragmatism (YAGNI)**: Apply the shared decision ladder in order. Implementations must be minimal without weakening correctness, safety, accessibility, or verification.
+- **Ponytail Pragmatism (YAGNI)**: Apply the shared decision ladder in order. Planned work must be minimal without weakening correctness, safety, accessibility, or verification coverage.
 - **Non-Blocking**: Identify drift without converting style preferences into hard failures.
 
 ## Detection Scope
 
 Detect violations such as:
-- **Intent Divergence**: Implementation deviates fundamentally from the specification or design intent.
-- **Hallucinated Abstractions**: Plan mentions an abstraction (e.g., Repository) that is missing in code.
-- **Boundary Erosion**: Business logic leaking into entry points or UI.
-- **Tight Coupling**: Circular dependencies or cross-module leakage.
-- **Duplication Drift**: The same rule, validation, mapping, or workflow is implemented in multiple places instead of a shared boundary.
+- **Intent Divergence**: The design or tasks deviate fundamentally from the specification intent.
+- **Unsupported Abstractions**: The plan introduces an abstraction without a requirement, ownership boundary, or task coverage.
+- **Boundary Erosion**: The plan assigns business logic to entry points or UI.
+- **Tight Coupling**: The planned module relationships introduce circular dependencies or cross-module leakage.
+- **Duplication Drift**: The same rule, validation, mapping, or workflow is planned in multiple places instead of a shared boundary.
 - **Contract Mismatch**: Mismatch between API, UI, or service shapes.
-- **Ponytail Violation (Bloat)**: Code is over-engineered, duplicates an existing capability, adds avoidable files or dependencies, includes unnecessary boilerplate or future-proofing, or bypasses a correct standard-library or native-platform feature.
+- **Ponytail Violation (Bloat)**: The plan introduces unnecessary abstractions, modules, dependencies, boilerplate, or future-proofing instead of the smallest design that satisfies the requirements.
 - **Ponytail Violation (Unsafe Simplification)**: A small diff removes required validation, authorization, data-loss prevention, accessibility, external-system safeguards, or verification.
-- **Root-Cause Miss**: A symptom is patched in one caller while sibling callers remain exposed to the same shared defect.
+- **Root-Cause Miss**: The plan addresses one affected path while omitting sibling paths that share the same defect.
 - **Constitution Breach**: Any conflict with a "MUST" principle in the Constitution.
 
 **Duplication Drift Example**
-- Finding: Both `checkout/controller.ts` and `checkout/service.ts` calculate the same tax rule.
-- Evidence: Each file applies the same conditional logic for the same inputs.
-- Recommended Fix: Keep the rule in the shared service/domain boundary and make the controller delegate to it.
+- Finding: The plan assigns the same tax rule to both the checkout entry boundary and application service.
+- Evidence: Separate plan or task entries assign the same decision to both boundaries.
+- Recommended Fix: Plan one owner in the service/domain boundary and make the entry boundary delegate to it.
 
 **Common DRY Signals**
 - Repeated business rules, approvals, validation, DTO mapping, or orchestration across multiple layers.
@@ -129,7 +139,7 @@ Detect violations such as:
 4. **Scan Principles**: Apply Review Principles across the planned boundaries.
 5. **Target Classification**: Determine which artifact each finding targets based on the finding's source evidence. Emit the adapter-resolved filename: `plan.md` for SpecKit planning artifacts, `design.md` for OpenSpec design artifacts, and the applicable `proposal.md`, `spec.md`, or `tasks.md` otherwise. For multi-artifact findings, set `Target:` to the authoritative artifact (`spec.md` > planning artifact (`plan.md` or `design.md`) > `tasks.md` > `proposal.md`).
 6. **Security & Governance Cross-Check**:
-  - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
+  - If a security constraint is breached, preserve the severity and blocking status defined by the governing security policy; category alone does not make it Critical.
   - Cross-reference architecture decisions with security trust boundaries.
 7. **Ponytail Audit**: Apply both sides of the shared contract to the plan. Check for planned bloat and unsafe under-building.
 8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
@@ -153,7 +163,7 @@ For all other violations, cite specific planning locations, lines, or patterns. 
 
 ## Severity Guide
 
-- **CRITICAL**: Violates Constitution MUST, breaches Security Constraint, or has zero implementation evidence for a required boundary.
+- **CRITICAL**: Policy-designated critical Constitution or security violation, or omission of all planned structure/design/task coverage for a required boundary. Record blocking status separately from severity.
 - **HIGH**: Significant boundary erosion, contract inconsistency, or fundamental intent divergence.
 - **MEDIUM**: Pattern drift or local inconsistency that creates technical debt.
 - **LOW**: Minor naming, shape, or structure drift.
@@ -164,14 +174,14 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Target | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `{adapter_path:arch-constitution}` | `{adapter_path:plan}` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
+| ID | Category | Severity | Blocking | Location(s) | Target | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | [Yes/No, from policy] | `{adapter_path:arch-constitution}` | `{adapter_path:plan}` | Violation of [Principle Name] | [Evidence from spec/plan/tasks] |
 
 ### Task Synchronization
 - **Status**: [Synced / Drifted]
-- **Missing Implementations**: [Files referenced in tasks but missing/empty]
-- **Pending Tasks**: [Incomplete tasks blocking architecture]
+- **Missing Coverage**: [Requirements or planned boundaries without tasks]
+- **Planning Gaps**: [Missing design or verification work that blocks architecture]
 
 ### Metrics
 - **Constitution Compliance**: [e.g. 90%]
@@ -217,7 +227,7 @@ Findings categorized by severity based on the active hygiene rules.
 1. **Critical Fixes**: Address Constitution and Security violations first.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
-4. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
+4. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, include proposed memory entries in the report. After returning the report-only structure, request approval in a separate interaction and write only approved entries.
 5. **Next Step**: Run `/ag-apply` to resolve all findings (plan/tasks findings will be applied directly; upstream findings in `proposal.md` or `spec.md` will be delegated with confirmation).
 6. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -4,6 +4,16 @@ description: Review implementation code or pre-implementation planning artifacts
 
 # Architecture Review Command
 
+## SDD Adapter Resolution
+
+Before executing this command, read `adapters/resolve.md`. Resolve the active adapter in this order:
+
+1. An explicit `--adapter` override, when provided.
+2. `.architecture-guard/selected-adapter`, which is authoritative after CLI installation.
+3. Filesystem markers only when no persisted selection exists.
+
+Load `adapters/{tool}.md` and resolve every `{adapter_path:key}` and `{adapter_command:key}` token before reviewing changed files or implementation artifacts. Stop if the adapter is missing or any token remains unresolved.
+
 ## Ponytail Core Contract
 
 Before continuing, you **MUST** read and apply `{adapter_path:ponytail-template}` (or `templates/ponytail_core.md` in the extension source checkout) as the authoritative shared contract. Phase instructions may narrow but not weaken its safety or verification floor.
@@ -36,8 +46,7 @@ When you see this marker in a step, evaluate these conditions:
    - OR the Flash-Mem context contains $> 20$ memory documents.
    - Otherwise, you **MUST** execute inline.
 3. **Override Command:** Explicit `--inline` or `--delegate` CLI flags override the auto-detection triggers above, but `--delegate` cannot bypass the capability gate.
-4. **Execution Syntax:** To delegate, call the sub-agent via the following pattern:
-   `/[extension_name].[sub_agent_command] --files=[comma_separated_file_list] --rules=[path_to_rules]`
+4. **Execution Semantics:** Use the host's registered sub-agent/task delegation capability, passing the target files, rules path, context, and expected output as structured input. Wait for its result and validate the returned evidence before integrating it. If the host has no such capability, execute inline and report that delegation was unavailable.
 5. **Strict Handoff Template:** When spawning the sub-agent, you must format your invocation prompt exactly like this:
    ```yaml
    Task: Analyze code quality and boundary violations.
@@ -68,7 +77,7 @@ This pattern ensures that lower-tier models follow strict execution paths instea
 
 **Coexistence Model**:
 - Review always starts technology-agnostic
-- If preset detected in `.specify/presets/` or the Constitution: Enhance with framework vocabulary
+- If adapter-resolved preset guidance or Constitution guidance is available: Enhance with framework vocabulary
 - Violations list remains the same; explanation becomes framework-native
 - Example: "Entry boundary contamination" (agnostic) → "Controller mixing HTTP and business logic" (Laravel-aware)
 
@@ -79,7 +88,8 @@ This pattern ensures that lower-tier models follow strict execution paths instea
 1. **Normalize Arguments**: Parse "$ARGUMENTS" to identify the `mode` (`architecture` or `performance`) and `focus` aspects (`general`, `db`, `api`, or `async`).
 2. **Identify Changed Files**:
    - If the user provided a file list or explicit instructions, follow them.
-   - Otherwise, you **MUST** execute `architecture-guard detect-changed-files --json` to detect changed files since the merge-base or in the working directory.
+   - Otherwise, use `architecture-guard detect-changed-files --json` only after confirming that capability is available.
+   - If unavailable, derive the set with the host's Git capability: include committed changes from the merge-base to `HEAD`, staged changes, unstaged changes, and untracked files. If Git is unavailable, ask the user for a file list and report that automatic detection could not run.
    - Use the `changed_files` list as the primary review set.
 
 ## Input & Context Loading
@@ -89,6 +99,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 1. **Governance & Security Constitution**:
     - `{adapter_path:constitution}`
     - `{adapter_path:security-constitution}`
+    - Missing optional constitution files do not stop review; use the available constitutions and report each fallback or omission.
 
 2. **Architecture Constitution**:
     - `{adapter_path:arch-constitution}`
@@ -154,14 +165,14 @@ Detect violations such as:
 
 ## Review Procedure
 
-1. **Identify Scope**: Run `architecture-guard detect-changed-files --json` or use user-provided files.
+1. **Identify Scope**: Reuse the scope resolved by **Determine Review Scope**: user-provided files first, then `architecture-guard detect-changed-files --json` when available, then the host Git fallback; ask the user when none is available.
 2. **Model Context**: Load artifacts and build the Semantic Models for the identified scope.
 3. **Verify Evidence**: Check if task-referenced files exist and contain expected implementation logic.
 4. **Analyze Alignment**: Compare the initial specification intent vs. the proposed architectural design vs. implementation behavior. Ensure the implementation accurately satisfies the spec without violating constraints.
 5. **Scan Principles**: Apply Review Principles across the implemented boundaries.
 6. **Security & Governance Cross-Check**:
-  - If `security-constraints.md` or `security_constitution.md` is breached, log it as a critical violation.
-  - If a finding is primarily security-related and Security Review is available, route it to `/speckit.security-review.branch` instead of duplicating it here.
+  - If a security constraint is breached, preserve the severity and blocking status defined by the governing security policy; category alone does not make it Critical.
+  - If a finding is primarily security-related and Security Review is available, dispatch the detected host capability's branch/implementation operation directly instead of duplicating it here.
   - Cross-reference architecture decisions with security trust boundaries.
 7. **Ponytail Audit**: Apply both sides of the shared contract. Check for bloat and unsafe under-building; trace changed shared behavior to its callers; verify the earliest viable ladder rung was used; and confirm non-trivial logic has a runnable check.
 8. **Performance Scan (if mode=performance)**: Skip violations; focus on optimizations.
@@ -186,15 +197,14 @@ When the extension is installed, load the bundle from `{adapter_path:sonar-rules
 
 ### Scope-Based Delegation (Hybrid Model)
 
-**Capability Gate:** First confirm that `/analyze-sonar-violations` is registered and callable. If it is unavailable, execute inline regardless of size.
+**Capability Gate:** First confirm that a host sub-agent capable of Sonar analysis is registered and callable. If it is unavailable, execute the heuristic rules-bundle analysis inline regardless of size.
 
 **Trigger Condition:** When the capability is available, you **MUST** delegate to the sub-agent if:
 - Changed files is $\ge 15$.
 - OR total lines in diff is $\ge 500$.
 - Otherwise, you **MUST** execute inline.
 
-**Execution Syntax:**
-* Custom command: `/analyze-sonar-violations --files=[comma_separated_file_list] --rules={adapter_path:sonar-rules}/sonarlint-rules.json`.
+**Execution Semantics:** Use the host's registered sub-agent/task delegation capability with the handoff below, wait for completion, and validate returned file/line evidence before integration.
 
 **Strict Handoff Template:**
 When delegating, write the sub-agent invocation prompt exactly like this:
@@ -210,7 +220,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 
 **If inline**:
 1. **Load Rules**: Read the installed extension bundle at `{adapter_path:sonar-rules}/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
-2. **Scan Changed Files**: Simulate or invoke SonarLint logic on `changed_files` list
+2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)
 5. **Deduplicate**: If a violation is already in architecture violations list, suppress from SonarLint output
@@ -235,7 +245,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 Add a new section in the report (see Output Format below):
 
 ```markdown
-### Code Quality Findings (SonarLint)
+### Code Quality Findings ([SonarLint / Heuristic Sonar Rules Analysis])
 
 Findings that correlate with architecture concerns:
 
@@ -263,7 +273,7 @@ For all other violations, cite specific code locations, line numbers, or pattern
 
 ## Severity Guide
 
-- **CRITICAL**: Violates Constitution MUST, breaches Security Constraint, or has zero implementation evidence for a required boundary.
+- **CRITICAL**: Policy-designated critical Constitution or security violation, or zero implementation evidence for a required boundary. Record blocking status separately from severity.
 - **HIGH**: Significant boundary erosion, contract inconsistency, or fundamental intent divergence.
 - **MEDIUM**: Pattern drift or local inconsistency that creates technical debt.
 - **LOW**: Minor naming, shape, or structure drift.
@@ -274,9 +284,9 @@ Return only this structure:
 
 # Architecture Review Report
 
-| ID | Category | Severity | Location(s) | Summary | Evidence/Rationale |
-|:---|:---|:---|:---|:---|:---|
-| V1 | Constitution | CRITICAL | `{adapter_path:arch-constitution}` | Violation of [Principle Name] | [Evidence from code/plan] |
+| ID | Category | Severity | Blocking | Location(s) | Summary | Evidence/Rationale |
+|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Constitution | CRITICAL | [Yes/No, from policy] | `{adapter_path:arch-constitution}` | Violation of [Principle Name] | [Evidence from code/plan] |
 
 ### Task Synchronization
 - **Status**: [Synced / Drifted]
@@ -305,14 +315,14 @@ Return only this structure:
 - **Suggestion**: 
 - **Trade-off**: 
 
-(Only if `mode=architecture` and SonarLint findings detected)
-### Code Quality Findings (SonarLint)
+(Only if `mode=architecture` and code-quality findings were produced)
+### Code Quality Findings ([SonarLint / Heuristic Sonar Rules Analysis])
 
 Findings that correlate with architecture concerns:
 
 | Rule | Severity | File | Issue | Architecture Signal |
 |:---|:---|:---|:---|:---|
-| `brain-overload::...` | HIGH | service/checkout.ts:45 | Function has 8 parameters | Hidden boundary: pricing logic should be in dedicated module |
+| `[Tool rule key or heuristic identifier]` | HIGH | service/checkout.ts:45 | Function has 8 parameters | Hidden boundary: pricing logic should be in dedicated module |
 
 **Note**: Pure style violations (formatting, naming) are filtered out. Only findings related to complexity, coupling, and structure are included.
 
@@ -341,13 +351,12 @@ Findings categorized by severity based on the active hygiene rules.
 2. **Architecture Alignment**: Resolve boundary erosion and contract mismatches.
 3. **Code Quality**: Address SonarLint findings that map to architectural concerns (if any).
 4. **DRY Alignment**: Centralize repeated business logic, validation, and mapping before duplicating it in another layer or module.
-5. **Durable Memory Preservation (Mandatory Check)**: If new architectural patterns, decisions, or repeatable lessons were identified, you **MUST automatically execute** the durable-memory capture flow immediately after providing the report. Do not just recommend it; let the formal capture flow propose entries and request user approval.
-6. **Next Step**: [e.g. Run `/speckit.security-review.branch` for security-first findings, or `/ag-apply` for architecture fixes]
+5. **Durable Memory Preservation (Mandatory Check)**: Include proposed durable-memory entries in the report when warranted. Return the complete report first; then request approval in a separate interaction and write only approved entries.
+6. **Next Step**: [e.g. Dispatch the detected host Security Review capability for security-first findings, or run `/ag-apply` for architecture fixes]
 7. **Remediation**: [Concrete remediation direction for the top issues, or "None needed"]
 
 ## Framework Preset Guidance
 
 If framework preset guidance exists, it is **mandatory** to use it to map generic principles to framework primitives and detect stack-specific anti-patterns.
 
-Preset path:
-- `{adapter_path:presets}`
+Preset guidance: use only `{adapter_path:presets}` when it resolves to an existing adapter-provided preset.

--- a/orchestration/verify.md
+++ b/orchestration/verify.md
@@ -4,9 +4,9 @@ description: Verify implementation against specification, design, plan, tasks, a
 
 # Architecture Verification
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -30,15 +30,15 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 
 - **REPOSITORY READ-ONLY**: This analytical gate does not modify repository files. It may write validated durable knowledge to Flash-Mem only after explicit user approval.
 - **Evidence-Based**: Every "Verified" or "Missing" status must cite specific files or code patterns.
-- **Constitution Authority**: The `architecture_constitution.md` is the non-negotiable standard for this check.
+- **Constitution Authority**: The adapter-resolved architecture rules are the non-negotiable standard. When an adapter declares the split architecture constitution optional, use the architecture rules embedded in `{adapter_path:constitution}` and record that provenance; if neither exists, mark architecture coverage `Degraded` and do not claim compliance.
 
 ## Execution Steps
 
 ### 1. Initialize Context
 
-1. Resolve explicit artifact paths from native user input first; otherwise discover existing artifacts by matching `{adapter_path:tasks}`, `{adapter_path:plan}`, and `{adapter_path:spec}`. If multiple active sets are plausible, ask the user instead of guessing.
+1. Resolve explicit artifact paths from native user input first; otherwise discover existing artifacts by matching `{adapter_path:tasks}`, `{adapter_path:plan}`, and `{adapter_path:spec}`. If multiple active sets are plausible, ask the user instead of guessing. If an optional artifact is absent, use an adapter-documented fallback only for the checks it can support, record its provenance, and mark unsupported checks `Degraded` rather than inventing evidence.
 2. Resolve the selected artifact set to absolute paths without invoking SDD-tool-specific prerequisite scripts.
-3. Load the Architecture Constitution: `{adapter_path:arch-constitution}`.
+3. Load `{adapter_path:arch-constitution}` when present; otherwise use adapter-documented architecture rules embedded in `{adapter_path:constitution}` and record the fallback.
 4. Load the Repository Hygiene Config: `{adapter_path:governance-config}` (fallback to `repository_hygiene` block in constitution).
 5. Load the Repository Hygiene Rules: `{adapter_path:hygiene-rules}`.
 
@@ -48,6 +48,7 @@ Build internal representations:
 - **Task-Boundary Map**: Associate each task with its intended architecture layer (Entry, Application, Domain, Data, External).
 - **Implementation Evidence**: For each completed task (`[x]`), scan referenced files for logic that addresses the task description.
 - **Contract Inventory**: Extract planned API/Data signatures from the technical design artifact.
+- **Requirement Evidence Map**: Map every specification requirement and acceptance criterion to its plan/tasks representation and concrete implementation/test evidence.
 - **Duplication Check**: Look for repeated business logic, validation, or transformation across files and confirm it has been centralized or explicitly justified.
 
 **Common DRY Signals**
@@ -61,6 +62,8 @@ Build internal representations:
 - **Ghost Tasks**: Tasks marked complete but with no evidence in the referenced files.
 - **Orphaned Code**: Implementation logic present in files that wasn't planned in `tasks.md`.
 - **Missing Files**: Files referenced in tasks that do not exist on disk.
+- **Requirement Coverage**: Every requirement and acceptance criterion must be `Verified`, `Partial`, `Missing`, or `Not Applicable` with cited artifact and code/test evidence.
+- **Artifact Contradictions**: Report conflicting requirements, acceptance criteria, design decisions, or completion claims across spec, plan, and tasks; do not resolve contradictions by silently choosing one artifact.
 
 #### B. Boundary Integrity
 - **Layer Violation**: Logic from one layer (e.g., Database queries) appearing in another layer (e.g., Controllers/Entry).
@@ -72,27 +75,35 @@ Build internal representations:
 - **Pattern Match**: Does the code follow the mandated architectural patterns (e.g., DTOs, Repositories, Events)?
 
 #### D. Security Review on Implementation
-- If `security-review` (or compatibility alias `spec-kit-security-review`) is available, run `{adapter_command:security-review}` against the verified implementation.
+- Detect Security Review independently from host registrations, never from the selected SDD tool or extension files.
+- If available, dispatch the detected host Security Review capability's implementation operation directly and include a separate Security Review section in the output. Do not execute adapter fallback prose as a command.
+- If unavailable, perform only architecture-visible security checks required by loaded constitutions, mark the independent security review `Unavailable`, and report degraded coverage without claiming a pass.
 - If security findings are architecture-relevant, classify them as `Security-Architecture Conflict`.
 
 #### E. Repository Hygiene Validation
 - Run all loaded hygiene rules against the repository, respecting configured exclusions from `repository_hygiene` config.
-- If a finding's severity matches the `fail_on` list in the configuration, elevate it to CRITICAL to fail the verification gate.
-- Other findings should be reported as Warnings or Info based on their base severity or the `warn_on` configuration.
+- Determine effective severity and blocking status from the applicable policy: architecture P0 rules, security policy, and hygiene `fail_on`/`warn_on` configuration remain independent. A finding blocks only when its governing policy says it blocks; category alone never changes severity.
 
 ### 4. Severity Assignment
 
-- **CRITICAL**: Task marked done but implementation is missing; Constitution "MUST" violation; Boundary bypass (e.g., direct DB access from UI).
+- Preserve each governing policy's native severity, then record `Blocking: Yes/No` separately. Architecture P0 and configured hygiene/security blocking levels fail the gate; advisory findings do not.
+- **CRITICAL**: Task marked done but implementation is missing; policy-designated critical Constitution violation; Boundary bypass (e.g., direct DB access from UI).
 - **HIGH**: Contract mismatch; Missing error-handling/edge-cases from spec; Major boundary erosion; repeated business rules with no shared extraction.
 - **MEDIUM**: Pattern drift; Task-referenced file exists but logic is incomplete.
 - **LOW**: Naming inconsistencies; Minor structure drift.
 
 ## Verification Report
 
-| ID | Category | Severity | Location(s) | Target | Summary | Recommendation |
-|:---|:---|:---|:---|:---|:---|:---|
-| V1 | Task Integrity | CRITICAL | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
-| V2 | Boundary | HIGH | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
+| ID | Category | Severity | Blocking | Location(s) | Target | Summary | Recommendation |
+|:---|:---|:---|:---|:---|:---|:---|:---|
+| V1 | Task Integrity | CRITICAL | Yes | `tasks.md:T01` | `tasks.md` | Task marked complete but logic missing in `auth.ts` | Implement logic or uncheck task |
+| V2 | Boundary | HIGH | No | `ctrl/user.ts` | `{adapter_path:plan}` | Database query found in Controller layer | Move query to Repository/Data layer |
+
+### Requirement Evidence
+
+| Requirement / Acceptance Criterion | Status | Spec Evidence | Plan / Task Evidence | Code / Test Evidence |
+|:---|:---|:---|:---|:---|
+| [Requirement ID or summary] | [Verified / Partial / Missing / Not Applicable] | [Path:line] | [Path:line] | [Path:line or explicit absence] |
 
 ### Task Status Analysis
 For each task in `tasks.md`:
@@ -104,6 +115,11 @@ For each task in `tasks.md`:
 - **Critical Issues**: [List any hygiene issues that fail verification]
 - **Warnings**: [List non-blocking hygiene warnings]
 - **Info**: [List minor hygiene notes]
+
+### Security Review Status
+- **Capability**: [Available / Unavailable]
+- **Coverage**: [Independent / Degraded]
+- **Blocking Findings**: [Policy-derived findings or None]
 
 ### Metrics
 - **Tasks Verified**: [Completed / Total]

--- a/orchestration/violation-detection.md
+++ b/orchestration/violation-detection.md
@@ -4,9 +4,9 @@ description: Detect technology-agnostic architecture violations in plans, tasks,
 
 # Violation Detection Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -120,21 +120,24 @@ A Security-Architecture Conflict occurs when security requirements and architect
 
 ## Review Procedure
 
-1. **Model Context**: Load artifacts and build the Semantic Models.
+1. **Resolve Bounded Scope**: Use an explicit user-provided file list first. Otherwise, use `architecture-guard detect-changed-files --json` only after confirming that capability is available. If unavailable, derive the set with the host's Git capability, including committed changes from the merge-base to `HEAD`, staged changes, unstaged changes, and untracked files. If Git is unavailable, ask the user for a file list and do not scan an unbounded repository scope.
+2. **Model Context**: Load artifacts and build the Semantic Models for the resolved scope.
 
     #### Flash-Mem Context Retrieval
     When Flash-Mem is available, use it first to gather the most relevant architecture context before judging violations. Prefer summary-first context and only expand into repository files when needed.
 
     If Flash-Mem is unavailable or the context is insufficient, continue with the repository artifacts and constitution files available in the workspace.
-2. **Verify Evidence**: Check if task-referenced files exist and contain expected implementation logic.
-3. **Analyze Alignment**: Compare `spec.md` intent vs. the technical design artifact architecture vs. actual behavior.
-4. **Scan Principles**: Apply detection scope across boundaries and contracts.
-5. **Security & Governance Cross-Check**: Ensure architecture decisions do not violate `{adapter_path:security-constitution}` or `{adapter_path:security-constraints}`.
-6. **Assign Severity**:
+3. **Verify Evidence**: Check if task-referenced files exist and contain expected implementation logic.
+4. **Analyze Alignment**: Compare `spec.md` intent vs. the technical design artifact architecture vs. actual behavior.
+5. **Scan Principles**: Apply detection scope across boundaries and contracts.
+6. **Security & Governance Cross-Check**: Ensure architecture decisions do not violate `{adapter_path:security-constitution}` or `{adapter_path:security-constraints}`. Classify severity and blocking status from the applicable policy, regardless of whether the finding is categorized as security, architecture, or governance.
+7. **Assign Severity, Blocking, and Priority**:
    - `Critical`: A governing rule explicitly assigns Critical/P0, or zero evidence exists for a required boundary. Security category alone does not set severity.
    - `High`: Significant boundary erosion, contract inconsistency, or intent divergence.
    - `Medium`: Local drift or debt.
    - `Low`: Minor shape or naming drift.
+   - `Blocking`: `Yes` only when the applicable policy explicitly marks the violation blocking; otherwise `No`. Severity does not imply blocking.
+   - `Priority`: `P0` only when `Blocking: Yes`; otherwise assign the applicable non-P0 priority from policy or severity.
 
 ## Output Format
 
@@ -144,6 +147,8 @@ Return only:
 Violations:
 - Type:
   Severity:
+  Blocking:
+  Priority:
   Location:
   Description:
   Evidence:
@@ -169,8 +174,7 @@ Feed detected violations to `{adapter_command:refactor-generator}` so they can b
 
 If framework preset guidance exists, use it to map the Generic Architecture Model to framework primitives and detect stack-specific anti-patterns.
 
-Preset path:
-- `{adapter_path:presets}/architecture-guard-preset.md`
+Preset guidance: use the adapter-resolved `{adapter_path:presets}` content when it exists.
 
 ## Backward Compatibility
 

--- a/orchestration/workflow.md
+++ b/orchestration/workflow.md
@@ -4,9 +4,9 @@ description: Run a single architecture workflow with optional memory context and
 
 # Architecture Workflow Command
 
-## SDD Tool Detection
+## SDD Adapter Resolution
 
-Before executing command, read `adapters/detect.md` to determine the active SDD tool. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
+Before executing command, read `adapters/resolve.md` to resolve the selected SDD adapter. Load `adapters/{tool}.md` for path maps, command maps, and gap fills. All paths and commands below use the loaded adapter.
 
 ## Ponytail Core Contract
 
@@ -63,11 +63,11 @@ The workflow is serial and ownership-aware:
 
 ## Goal
 
-Review the current specification, plan, task list, or implementation with a single workflow and produce the most useful next step.
+Review one resolved active specification, plan, task list, or implementation set with a single workflow and produce the most useful next step.
 
 ## Inputs To Consider
 
-Review any available artifacts from these common locations. **IMPORTANT**: You MUST read these files explicitly using your file-reading tools (absolute or relative paths). Do not rely solely on workspace search or semantic indexers, as these files are often in `.gitignore`:
+Resolve explicit user paths first; otherwise use `{adapter_path:spec}`, `{adapter_path:plan}`, `{adapter_path:tasks}`, and `{adapter_path:security-constraints}` for one active adapter artifact set. If branch metadata and adapter paths identify different sets, or multiple sets remain plausible, stop and ask the user instead of combining them. Read resolved files explicitly because they may be ignored by search.
 
 1. **Governance & Security Constitution**:
    - `{adapter_path:constitution}`
@@ -77,8 +77,8 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
    - `{adapter_path:arch-constitution}`
 
 3. **Feature-Specific Context**:
-   - `{adapter_path:security-constraints}`
-   - `spec.md`, the technical design artifact, `tasks.md`, `data-model.md`
+    - `{adapter_path:security-constraints}`
+    - `{adapter_path:spec}`, `{adapter_path:plan}`, and `{adapter_path:tasks}`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.
@@ -87,16 +87,17 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 1. Read Flash-Mem context first if it is available in the project or workflow context, then fall back to repository files if needed.
 2. Review the current work against the Constitution and generic architecture principles.
-3. Identify whether any finding is primarily security-related.
-4. If a finding is security-related, flag it as a handoff to Security Review rather than treating it as a core architecture finding.
+3. Detect Security Review independently from host registrations, not adapter extension support, and identify whether any finding is primarily security-related.
+4. If Security Review is available, hand off security-first findings. If unavailable, report the capability as unavailable, perform only constitution-required architecture-visible security checks, and mark security coverage degraded without claiming a security pass.
 5. Produce refactor tasks or an apply recommendation as needed.
 6. Prefer a single concise summary that tells the user what to fix next.
+7. Run hygiene rules only across the resolved review scope plus repository-level files explicitly required by each rule. Apply configured exclusions, preserve policy severity, and record blocking status separately.
 
 ## Rules
 
 - Do not invent framework-specific conventions.
 - Do not invent unsupported framework APIs; use adapter behavior and fallbacks.
-- Do not block implementation by default.
+- Do not block implementation by default. Block only architecture P0 or findings whose applicable security/hygiene policy explicitly designates them blocking; capability availability and finding category do not imply severity.
 - Do not replace Security Review; route security-first findings to Security Review when available.
 - Do not require `flash-mem`; treat it as optional read-only context only.
 - Do not duplicate Security Review findings in the architecture output unless the issue is specifically an architectural boundary problem.
@@ -114,7 +115,7 @@ All governance reports MUST follow this standard template:
 
 ## Input Summary
 - **Artifacts Scanned**: [list]
-- **Extensions Used**: [`flash-mem`: yes/no, Security Review: yes/no]
+- **Capabilities Used**: [`flash-mem`: yes/no, Security Review: available/unavailable]
 - **Mode**: [architecture/performance]
 - **Focus**: [general/db/api/async]
 
@@ -132,6 +133,7 @@ All governance reports MUST follow this standard template:
 ## Context Applied
 - **`flash-mem`**: [Used context or "Not available"]
 - **Security Review**: [Findings routed or "Not available"]
+- **Security Coverage**: [Independent / Degraded]
 
 ## Recommended Next Step
 [Single clear action]

--- a/orchestration/workflow.md
+++ b/orchestration/workflow.md
@@ -77,8 +77,8 @@ Resolve explicit user paths first; otherwise use `{adapter_path:spec}`, `{adapte
    - `{adapter_path:arch-constitution}`
 
 3. **Feature-Specific Context**:
-    - `{adapter_path:security-constraints}`
-    - `{adapter_path:spec}`, `{adapter_path:plan}`, and `{adapter_path:tasks}`
+   - `{adapter_path:security-constraints}`
+   - `{adapter_path:spec}`, `{adapter_path:plan}`, and `{adapter_path:tasks}`
    - Stored architecture decisions from Flash-Mem, if present.
    - Security Review findings, if present.
    - Optional preset guidance, if present.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "architecture-guard",
   "version": "2.3.5",
-  "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Detects the active SDD tool and applies the matching adapter automatically.",
+  "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Resolves the selected SDD adapter and applies its mappings automatically.",
   "bin": {
     "architecture-guard": "./dist/bin/cli.js"
   },


### PR DESCRIPTION
## Summary

- Make `src/orchestration/` the canonical standalone cross-SDD skill source.
- Preserve `src/commands/` as the self-contained legacy SpecKit extension channel.
- Replace adapter detection with persisted adapter resolution via `adapters/resolve.md`.
- Harden all 18 orchestration workflows and legacy counterparts with explicit write approvals, P0/security blocking rules, evidence schemas, safe archive behavior, and Generic/OpenSpec fallbacks.
- Keep current SpecKit Security Review support only in the legacy extension channel; standalone orchestration reports it unavailable until a separate compatible capability is added.
- Remove the standalone installer fallback to legacy `commands/` prompts and add parity/regression coverage.

## Validation

- `npm test` (20/20 passing)
- `git diff --check`
- Verified all canonical adapter tokens resolve for SpecKit, OpenSpec, and Generic.
- Verified no stale `adapters/detect.md` or `SDD Tool Detection` references remain under `src/`.
- Verified the CLI installs only canonical orchestration prompts and legacy SpecKit Security Review compatibility remains tested.

## Scope

All committed changes are in the nested `src` package repository. Parent-repository generated artifacts were intentionally not included.