### PR TITLE
fix(orchestrator): clarify SonarLint rules bundle resolution in review implementation prompts

### DIFF
--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -190,7 +190,7 @@ This step runs code quality checks using bundled SonarLint rules. It is **option
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
 Load the bundle in this deterministic order:
 1. Active extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` or `.architecture-guard/sonar-rules/sonarlint-rules.json`
-2. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
+2. Source checkout path: `sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -224,7 +224,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
+1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -188,7 +188,9 @@ Detect violations such as:
 
 This step runs code quality checks using bundled SonarLint rules. It is **optional** and complements architecture violations.
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
-When the extension is installed, load the bundle from `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`.
+Load the bundle in this deterministic order:
+1. Active extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` or `.architecture-guard/sonar-rules/sonarlint-rules.json`
+2. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -222,7 +224,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the installed extension bundle at `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
+1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -186,7 +186,10 @@ Detect violations such as:
 
 This step runs code quality checks using bundled SonarLint rules. It is **optional** and complements architecture violations.
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
-When the extension is installed, load the bundle from `{adapter_path:sonar-rules}/sonarlint-rules.json`.
+Load the bundle in this deterministic order:
+1. Active adapter path: `{adapter_path:sonar-rules}/sonarlint-rules.json` (resolves to `.architecture-guard/sonar-rules/sonarlint-rules.json`)
+2. Legacy extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`
+3. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -194,6 +197,7 @@ When the extension is installed, load the bundle from `{adapter_path:sonar-rules
 - Skip if user explicitly disables with `--no-sonarlint`
 - Skip if the repository does not contain a SonarLint rules bundle or the bundle is empty
 - If skipped, continue the rest of the architecture review and note that the optional SonarLint scan was unavailable
+
 
 ### Scope-Based Delegation (Hybrid Model)
 
@@ -219,7 +223,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the installed extension bundle at `{adapter_path:sonar-rules}/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
+1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -189,7 +189,7 @@ The rules bundle is repository-native and IDE-agnostic, so it works the same in 
 Load the bundle in this deterministic order:
 1. Active adapter path: `{adapter_path:sonar-rules}/sonarlint-rules.json` (resolves to `.architecture-guard/sonar-rules/sonarlint-rules.json`)
 2. Legacy extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`
-3. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
+3. Source checkout path: `sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -223,7 +223,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
+1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)


### PR DESCRIPTION
## Summary

This PR resolves an informational issue where code quality reviews (`ag-review-implementation` / `ag-verify`) could report `No SonarLint rules bundle was present` despite the bundle existing in the repository.

### Changes
- Updated `orchestration/review-implementation.md` and `commands/review-implementation.md` to explicitly declare the deterministic resolution order for the SonarLint rules bundle:
  1. Active adapter path: `{adapter_path:sonar-rules}/sonarlint-rules.json` (resolves to `.architecture-guard/sonar-rules/sonarlint-rules.json`)
  2. Legacy extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`
  3. Source checkout fallback paths: `sonar-rules/sonarlint-rules.json` and `src/sonar-rules/sonarlint-rules.json`
- Synchronized the inline procedure in both command and orchestration prompts.

## Verification
- `npm run build && npm test` passed (21/21 suites).
- OpenSpec change `resolve-sonarlint-rules-lookup` validated and archived.