### PR TITLE
fix(orchestrator): clarify repository hygiene rules resolution in review and verify prompts

### DIFF
--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -84,7 +84,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
-    - Rules: `.specify/extensions/architecture-guard/hygiene-rules/*.md`
+    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ## Semantic Modeling
 

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -190,7 +190,7 @@ This step runs code quality checks using bundled SonarLint rules. It is **option
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
 Load the bundle in this deterministic order:
 1. Active extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` or `.architecture-guard/sonar-rules/sonarlint-rules.json`
-2. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
+2. Source checkout path: `sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -224,7 +224,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
+1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -188,7 +188,9 @@ Detect violations such as:
 
 This step runs code quality checks using bundled SonarLint rules. It is **optional** and complements architecture violations.
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
-When the extension is installed, load the bundle from `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`.
+Load the bundle in this deterministic order:
+1. Active extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` or `.architecture-guard/sonar-rules/sonarlint-rules.json`
+2. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -222,7 +224,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the installed extension bundle at `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
+1. **Load Rules**: Read the rules bundle in order: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, `.architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -116,7 +116,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
-    - Rules: `.specify/extensions/architecture-guard/hygiene-rules/*.md`
+    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ## Semantic Modeling
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -38,7 +38,7 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 2. Derive absolute paths for active specification, design, and task artifacts.
 3. Load the Architecture Constitution: `.specify/memory/architecture_constitution.md`.
 4. Load the Repository Hygiene Config: `.specify/config/repository_hygiene.yml` (fallback to `repository_hygiene` block in constitution).
-5. Load the Repository Hygiene Rules: `.specify/extensions/architecture-guard/hygiene-rules/*.md`.
+5. Load the Repository Hygiene Rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ### 2. Semantic Modeling (Internal)
 

--- a/docs/repository-hygiene.md
+++ b/docs/repository-hygiene.md
@@ -61,7 +61,7 @@ The following hygiene categories are checked by default:
 
 ## Custom Rules
 
-You can add custom rules by placing markdown files into the `.specify/extensions/architecture-guard/hygiene-rules/` directory. 
+You can add custom rules by placing markdown files into the `.architecture-guard/hygiene-rules/` directory (or `.specify/extensions/architecture-guard/hygiene-rules/` when using legacy Spec Kit extensions, or `hygiene-rules/` in repository checkouts). 
 
 Each rule should follow this format:
 

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -84,7 +84,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
-    - Rules: `{adapter_path:hygiene-rules}`
+    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ## Semantic Modeling
 

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -186,7 +186,10 @@ Detect violations such as:
 
 This step runs code quality checks using bundled SonarLint rules. It is **optional** and complements architecture violations.
 The rules bundle is repository-native and IDE-agnostic, so it works the same in VS Code, Cursor, JetBrains, or CLI-only workflows.
-When the extension is installed, load the bundle from `{adapter_path:sonar-rules}/sonarlint-rules.json`.
+Load the bundle in this deterministic order:
+1. Active adapter path: `{adapter_path:sonar-rules}/sonarlint-rules.json` (resolves to `.architecture-guard/sonar-rules/sonarlint-rules.json`)
+2. Legacy extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`
+3. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -194,6 +197,7 @@ When the extension is installed, load the bundle from `{adapter_path:sonar-rules
 - Skip if user explicitly disables with `--no-sonarlint`
 - Skip if the repository does not contain a SonarLint rules bundle or the bundle is empty
 - If skipped, continue the rest of the architecture review and note that the optional SonarLint scan was unavailable
+
 
 ### Scope-Based Delegation (Hybrid Model)
 
@@ -219,7 +223,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the installed extension bundle at `{adapter_path:sonar-rules}/sonarlint-rules.json` first; if running from the extension source checkout, use `sonar-rules/sonarlint-rules.json`
+1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -189,7 +189,7 @@ The rules bundle is repository-native and IDE-agnostic, so it works the same in 
 Load the bundle in this deterministic order:
 1. Active adapter path: `{adapter_path:sonar-rules}/sonarlint-rules.json` (resolves to `.architecture-guard/sonar-rules/sonarlint-rules.json`)
 2. Legacy extension path: `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`
-3. Source checkout paths: `sonar-rules/sonarlint-rules.json` or `src/sonar-rules/sonarlint-rules.json`
+3. Source checkout path: `sonar-rules/sonarlint-rules.json`
 
 ### Activation
 
@@ -223,7 +223,7 @@ Expected Output: JSON list of CRITICAL/HIGH code quality violations mapped to ar
 ### Procedure
 
 **If inline**:
-1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json` / `src/sonar-rules/sonarlint-rules.json`.
+1. **Load Rules**: Read the rules bundle in order: `{adapter_path:sonar-rules}/sonarlint-rules.json`, `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json`, or source checkout `sonar-rules/sonarlint-rules.json`.
 2. **Scan Changed Files**: Apply the rules bundle heuristically to `changed_files`; label these findings `Heuristic Sonar Rules Analysis`. Label findings as actual `SonarLint` output only when a SonarLint tool was invoked and returned them.
 3. **Filter Results**: Keep only CRITICAL/HIGH severity findings related to complexity, coupling, structure
 4. **Map to Boundaries**: Correlate findings with architecture boundaries (Entry/App/Domain/Data/External)

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -116,7 +116,7 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
-    - Rules: `{adapter_path:hygiene-rules}`
+    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ## Semantic Modeling
 

--- a/orchestration/verify.md
+++ b/orchestration/verify.md
@@ -40,7 +40,7 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 2. Resolve the selected artifact set to absolute paths without invoking SDD-tool-specific prerequisite scripts.
 3. Load `{adapter_path:arch-constitution}` when present; otherwise use adapter-documented architecture rules embedded in `{adapter_path:constitution}` and record the fallback.
 4. Load the Repository Hygiene Config: `{adapter_path:governance-config}` (fallback to `repository_hygiene` block in constitution).
-5. Load the Repository Hygiene Rules: `{adapter_path:hygiene-rules}`.
+5. Load the Repository Hygiene Rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
 
 ### 2. Semantic Modeling (Internal)
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where running Architecture Guard in standalone tools mode could report `Hygiene rules unavailable - No active hygiene rule files were found` at `.architecture-guard/hygiene-rules/` due to single-path resolution.

### Changes
- Standardized the deterministic fallback resolution chain for repository hygiene rules across review and verify prompts:
  1. Active adapter path: `{adapter_path:hygiene-rules}` (resolves to `.architecture-guard/hygiene-rules/*.md`)
  2. Legacy extension path: `.specify/extensions/architecture-guard/hygiene-rules/*.md`
  3. Source checkout fallback path: `hygiene-rules/*.md` (relative to repository root)
- Updated prompts in:
  - `orchestration/review-artifacts.md` & `commands/review-artifacts.md`
  - `orchestration/review-implementation.md` & `commands/review-implementation.md`
  - `orchestration/verify.md` & `commands/verify.md`
- Updated documentation in `docs/repository-hygiene.md` to reflect both runtime and source checkout locations.

## Verification
- `npm run build && npm test` passed (21/21 suites).
- OpenSpec change `resolve-hygiene-rules-lookup` validated and archived.