### PR TITLE
fix(orchestrator): add hidden directory direct discovery guard and rule inventory reporting

### DIFF
--- a/cli/install.ts
+++ b/cli/install.ts
@@ -329,6 +329,7 @@ ${selectedAgents.map(agent => `- \`${path.join(AGENT_CONFIGS[agent].dir, '*')}\`
 - **Ponytail Core Contract**: Before spec/plan/tasks/implement, read and apply the ponytail pragmatism contract.
 - **After each phase**: Run architecture review for boundary drift, DRY violations, and repository hygiene.
 - **SDD Adapter Resolution**: Project uses the adapter selected during CLI init. Read \`adapters/resolve.md\` before first command.
+- **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as \`.architecture-guard/**\`, use direct directory inspection first, then read listed files. A Glob no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. Always include loaded rule files and counts in governance reports.
 `;
 
   if (fs.existsSync(agentsPath)) {

--- a/commands/review-artifacts.md
+++ b/commands/review-artifacts.md
@@ -84,7 +84,8 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
-    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+    - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The review report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ## Semantic Modeling
 

--- a/commands/review-implementation.md
+++ b/commands/review-implementation.md
@@ -116,7 +116,8 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `.specify/config/repository_hygiene.yml` (or `repository_hygiene` block in constitution).
-    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+    - Rules: Load rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+    - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The review report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ## Semantic Modeling
 

--- a/commands/verify.md
+++ b/commands/verify.md
@@ -38,7 +38,8 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 2. Derive absolute paths for active specification, design, and task artifacts.
 3. Load the Architecture Constitution: `.specify/memory/architecture_constitution.md`.
 4. Load the Repository Hygiene Config: `.specify/config/repository_hygiene.yml` (fallback to `repository_hygiene` block in constitution).
-5. Load the Repository Hygiene Rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+5. Load the Repository Hygiene Rules in deterministic order from `.specify/extensions/architecture-guard/hygiene-rules/*.md`, `.architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+   - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The verification report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ### 2. Semantic Modeling (Internal)
 

--- a/orchestration/review-artifacts.md
+++ b/orchestration/review-artifacts.md
@@ -84,7 +84,8 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
-    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+    - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The review report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ## Semantic Modeling
 

--- a/orchestration/review-implementation.md
+++ b/orchestration/review-implementation.md
@@ -116,7 +116,8 @@ Review any available artifacts from these common locations. **IMPORTANT**: You M
 
 5. **Repository Hygiene**:
     - Config: `{adapter_path:governance-config}` (or `repository_hygiene` block in constitution).
-    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+    - Rules: Load rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+    - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The review report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ## Semantic Modeling
 

--- a/orchestration/verify.md
+++ b/orchestration/verify.md
@@ -40,7 +40,8 @@ Perform a high-integrity verification of the implementation. Unlike a general re
 2. Resolve the selected artifact set to absolute paths without invoking SDD-tool-specific prerequisite scripts.
 3. Load `{adapter_path:arch-constitution}` when present; otherwise use adapter-documented architecture rules embedded in `{adapter_path:constitution}` and record the fallback.
 4. Load the Repository Hygiene Config: `{adapter_path:governance-config}` (fallback to `repository_hygiene` block in constitution).
-5. Load the Repository Hygiene Rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`. Missing optional hygiene rules are non-blocking; report if unavailable.
+5. Load the Repository Hygiene Rules in deterministic order from `{adapter_path:hygiene-rules}`, `.specify/extensions/architecture-guard/hygiene-rules/*.md`, or source checkout `hygiene-rules/*.md`.
+   - **Direct Discovery Guard**: When checking adapter-resolved hidden paths such as `.architecture-guard/**`, use direct directory inspection first, then read listed files. A Glob/search no-match result is inconclusive and MUST NOT be reported as missing. Report a path as unavailable only after direct inspection confirms it does not exist. The verification report MUST explicitly list loaded rule files and counts. Missing optional hygiene rules are non-blocking.
 
 ### 2. Semantic Modeling (Internal)
 


### PR DESCRIPTION
## Summary

This PR addresses false negatives when discovering rules and templates from adapter-resolved hidden paths (such as `.architecture-guard/**`). It prevents agents from misinterpreting inconclusive search/glob outputs on dot-directories as authoritative absences.

### Changes
- **Direct Discovery Guard**: Added explicit instructions across `install.ts` (generated `AGENTS.md`), review prompts, and verify prompts:
  - When checking adapter-resolved hidden paths (such as `.architecture-guard/**`), agents must use direct directory reading first, then read its listed files.
  - A Glob or search no-match result on dot-directories is inconclusive and must not be treated as an authoritative missing state.
  - A path may only be reported as unavailable after direct directory inspection confirms it does not exist.
- **Rule Inventory Reporting**: Required review and verification reports to explicitly include loaded rule files and counts.
- Updated prompt files:
  - `orchestration/review-artifacts.md` & `commands/review-artifacts.md`
  - `orchestration/review-implementation.md` & `commands/review-implementation.md`
  - `orchestration/verify.md` & `commands/verify.md`
- Updated `cli/install.ts` preamble generation for `AGENTS.md`.

## Verification
- `npm run build && npm test` passed (21/21 suites).
- OpenSpec change `guard-hidden-directory-discovery` validated and archived.