### PR TITLE
feat: add shift-left quality gates to governed workflows

### DIFF
--- a/commands/governed-implement.md
+++ b/commands/governed-implement.md
@@ -86,8 +86,12 @@ You must orchestrate the `/speckit.implement` (core implementation) workflow dir
    - Perform the actual coding work (writing files, running tests) for each task, enforcing Ponytail minimalism.
    - Note in the Governance Summary that `/speckit.implement` was unavailable and implementation was performed inline.
 3. **Write Code**: Perform the actual coding work (writing files, running tests) required by the tasks.
-4. **Sync the tasks**: You MUST update `specs/<feature>/tasks.md` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
-5. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
+4. **Inline Pre-Completion Self-Verification Gate**: Before marking any task complete:
+   - **Repository Hygiene Check**: Inspect changed files against hygiene rules (no `.tmp`, `.new`, or scratch files left behind; no commented-out code; no dead imports).
+   - **Heuristic SonarLint Scan**: Check changed files against SonarLint rules (ensure no cognitive overload, tight coupling, loose `any`/`unknown` casts, or missing parameter validation).
+   - **Immediate Remediation**: Correct any detected quality or hygiene violations immediately at the current task boundary.
+5. **Sync the tasks**: You MUST update `specs/<feature>/tasks.md` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
+6. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
 
 NOTE: The core Spec Kit command is `speckit.implement`. Do not use `speckit.implementation` as it is not a registered command.
 

--- a/commands/governed-plan.md
+++ b/commands/governed-plan.md
@@ -81,7 +81,12 @@ When Flash-Mem MCP is unavailable but the Memory MD CLI detected in Step 1 is pr
 You must orchestrate the `/speckit.plan` workflow directly.
 
 **CRITICAL INSTRUCTION**: You must NOT just advise the user or stop here. You must actually generate the plan:
-1. **Apply Ponytail Pragmatism**: Instruct the agent to act as a "lazy senior developer." The generated plan must prefer standard libraries and native platform features over proposing complex new abstractions. Strictly enforce YAGNI.
+1. **Apply Ponytail Pragmatism & Shift-Left Quality**: Instruct the agent to act as a "lazy senior developer." The generated plan must prefer standard libraries and native platform features over proposing complex new abstractions. Strictly enforce YAGNI.
+   - Proactively specify bounded collection reads and server-side pagination for all list/query endpoints.
+   - Proactively design explicit request/response DTO serialization envelopes and OpenAPI contracts.
+   - Proactively define input parameter validation (e.g. UUID pipes, sanitization) at controller/API boundaries.
+   - Proactively establish transaction failure-safety and error-recovery ownership boundaries.
+   - Proactively plan repository hygiene: explicitly declare target paths and forbid temporary/comparison artifacts or unverified schema clones.
    - Also prefer one shared plan path for repeated behavior instead of separate duplicated steps or parallel implementations.
 2. **Execute Plan**: Run `/speckit.plan` to generate and save the technical design document (e.g., `specs/<feature>/plan.md` or `openspec/.../design.md`).
 

--- a/commands/governed-tasks.md
+++ b/commands/governed-tasks.md
@@ -79,7 +79,12 @@ If Flash-Mem is unavailable or the context is insufficient, continue with the re
 You must orchestrate the `/speckit.tasks` workflow directly.
 
 **CRITICAL INSTRUCTION**: You must NOT just advise the user or stop here. You must actually generate the tasks:
-1. **Apply Ponytail Pragmatism**: Instruct the agent to act as a "lazy senior developer." Break down the work into the absolute minimal tasks needed. Refuse to add boilerplate, unnecessary abstractions, or "future-proofing" tasks.
+1. **Apply Ponytail Pragmatism & Quality-Enriched Decomposition**: Instruct the agent to act as a "lazy senior developer." Break down the work into the absolute minimal tasks needed. Refuse to add boilerplate, unnecessary abstractions, or "future-proofing" tasks.
+   - Embed explicit SonarLint/quality acceptance criteria in tasks:
+     - Type safety: strict discriminated unions, no unvalidated `any`/`unknown` casts.
+     - Controller/API boundaries: explicit parameter parsing/validation (e.g. UUID) and documented DTO response serialization.
+     - Localized verification: runnable unit/integration tests and lint/typecheck command execution.
+     - Hygiene confirmation: clean workspace with no leftover `.tmp`, `.new`, or commented-out code.
    - If the same logic appears in multiple modules, create a single extraction task instead of parallel copy-paste tasks.
 2. **Execute Tasks**: Run `/speckit.tasks` to generate and save `specs/<feature>/tasks.md`.
 

--- a/orchestration/governed-implement.md
+++ b/orchestration/governed-implement.md
@@ -83,9 +83,13 @@ You must orchestrate the `{adapter_command:implement}` (core implementation) wor
    - Perform the actual coding work (writing files, running tests) for each task, enforcing Ponytail minimalism.
    - Note in the Governance Summary that `{adapter_command:implement}` was unavailable and implementation was performed inline.
 3. **Write Code**: Perform the actual coding work (writing files, running tests) required by the tasks.
-4. **Sync the tasks**: You MUST update `{adapter_path:tasks}` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
+4. **Inline Pre-Completion Self-Verification Gate**: Before marking any task complete:
+   - **Repository Hygiene Check**: Inspect changed files against `{adapter_path:hygiene-rules}` (no `.tmp`, `.new`, or scratch files left behind; no commented-out code; no dead imports).
+   - **Heuristic SonarLint Scan**: Check changed files against `{adapter_path:sonar-rules}/sonarlint-rules.json` (ensure no cognitive overload, tight coupling, loose `any`/`unknown` casts, or missing parameter validation).
+   - **Immediate Remediation**: Correct any detected quality or hygiene violations immediately at the current task boundary.
+5. **Sync the tasks**: You MUST update `{adapter_path:tasks}` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
    - If implementation would expand beyond accepted spec/plan/task scope, stop and obtain explicit user approval before adding or executing that work. Record the approved expansion in the authoritative artifacts first.
-5. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
+6. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.
 
 The SDD-tool-native implementation behavior is defined only by `{adapter_command:implement}`.
 

--- a/orchestration/governed-plan.md
+++ b/orchestration/governed-plan.md
@@ -81,7 +81,12 @@ When Flash-Mem MCP is unavailable but the Memory MD CLI detected in Step 1 is pr
 You must orchestrate the `{adapter_command:create-plan}` workflow directly.
 
 **CRITICAL INSTRUCTION**: You must NOT just advise the user or stop here. You must actually generate the plan:
-1. **Apply Ponytail Pragmatism**: Instruct the agent to act as a "lazy senior developer." The generated plan must prefer standard libraries and native platform features over proposing complex new abstractions. Strictly enforce YAGNI.
+1. **Apply Ponytail Pragmatism & Shift-Left Quality**: Instruct the agent to act as a "lazy senior developer." The generated plan must prefer standard libraries and native platform features over proposing complex new abstractions. Strictly enforce YAGNI.
+   - Proactively specify bounded collection reads and server-side pagination for all list/query endpoints.
+   - Proactively design explicit request/response DTO serialization envelopes and OpenAPI contracts.
+   - Proactively define input parameter validation (e.g. UUID pipes, sanitization) at controller/API boundaries.
+   - Proactively establish transaction failure-safety and error-recovery ownership boundaries.
+   - Proactively plan repository hygiene: explicitly declare target paths and forbid temporary/comparison artifacts or unverified schema clones.
    - Also prefer one shared plan path for repeated behavior instead of separate duplicated steps or parallel implementations.
 2. **Execute Plan**: Run `{adapter_command:create-plan}` to generate and save `{adapter_path:plan}`.
 

--- a/orchestration/governed-tasks.md
+++ b/orchestration/governed-tasks.md
@@ -79,7 +79,12 @@ If Flash-Mem is unavailable or the context is insufficient, continue with the re
 You must orchestrate the `{adapter_command:create-tasks}` workflow directly.
 
 **CRITICAL INSTRUCTION**: You must NOT just advise the user or stop here. You must actually generate the tasks:
-1. **Apply Ponytail Pragmatism**: Instruct the agent to act as a "lazy senior developer." Break down the work into the absolute minimal tasks needed. Refuse to add boilerplate, unnecessary abstractions, or "future-proofing" tasks.
+1. **Apply Ponytail Pragmatism & Quality-Enriched Decomposition**: Instruct the agent to act as a "lazy senior developer." Break down the work into the absolute minimal tasks needed. Refuse to add boilerplate, unnecessary abstractions, or "future-proofing" tasks.
+   - Embed explicit SonarLint/quality acceptance criteria in tasks:
+     - Type safety: strict discriminated unions, no unvalidated `any`/`unknown` casts.
+     - Controller/API boundaries: explicit parameter parsing/validation (e.g. UUID) and documented DTO response serialization.
+     - Localized verification: runnable unit/integration tests and lint/typecheck command execution.
+     - Hygiene confirmation: clean workspace with no leftover `.tmp`, `.new`, or commented-out code.
    - If the same logic appears in multiple modules, create a single extraction task instead of parallel copy-paste tasks.
 2. **Execute Tasks**: Run `{adapter_command:create-tasks}` to generate and save `{adapter_path:tasks}`.
 

--- a/templates/ponytail_core.md
+++ b/templates/ponytail_core.md
@@ -39,6 +39,7 @@ Do not add one defensive patch per caller when a smaller shared root-cause corre
 - Add no avoidable dependency or boilerplate.
 - Prefer deletion over addition, boring over clever, and fewer files over unnecessary fragmentation.
 - Between equally small options, choose the one that remains correct on edge cases.
+- Shift quality and hygiene left: enforce bounded collection reads, explicit response/request DTO envelopes, parameter validation, and strict typing at the owning boundary. Zero tolerance for leftover temporary/scratch files, commented-out code, or unverified schema clones.
 - Deliver the simplest valid solution while clearly challenging unnecessary complexity; do not stall safe progress merely because the request could be simpler.
 - When accepting a deliberate limitation with a real ceiling, add a `ponytail:` note in the relevant code or artifact that names the ceiling and the upgrade path. Do not comment ordinary simplifications.
 


### PR DESCRIPTION
## Summary
- Extend the Ponytail contract with shift-left quality and hygiene expectations.
- Add bounded reads, DTO envelopes, boundary validation, transaction safety, and hygiene guidance to governed plan workflows.
- Add explicit type-safety, validation, verification, and hygiene acceptance criteria to governed task workflows.
- Add pre-completion hygiene and heuristic SonarLint checks to governed implementation workflows.
- Keep the legacy Spec Kit prompts and adapter-driven orchestration prompts aligned.

## Validation
- `npm run lint`
- `npm test` (build plus 21 tests)
- `git diff --check`

## Review note
- Corrected duplicate implementation step numbering introduced by the new self-verification gate.