### PR TITLE
feat(hygiene): add deprecated and dangerous code rule and self-learning flow

### DIFF
--- a/commands/governed-implement.md
+++ b/commands/governed-implement.md
@@ -87,8 +87,9 @@ You must orchestrate the `/speckit.implement` (core implementation) workflow dir
    - Note in the Governance Summary that `/speckit.implement` was unavailable and implementation was performed inline.
 3. **Write Code**: Perform the actual coding work (writing files, running tests) required by the tasks.
 4. **Inline Pre-Completion Self-Verification Gate**: Before marking any task complete:
-   - **Repository Hygiene Check**: Inspect changed files against hygiene rules (no `.tmp`, `.new`, or scratch files left behind; no commented-out code; no dead imports).
-   - **Heuristic SonarLint Scan**: Check changed files against SonarLint rules (ensure no cognitive overload, tight coupling, loose `any`/`unknown` casts, or missing parameter validation).
+   - **Deprecated & Dangerous Code Check**: Check changed and target files against `.specify/extensions/architecture-guard/hygiene-rules/deprecated-and-dangerous-code.md` (or local hygiene rules) to ensure no obsolete, deprecated, or fatal language/framework patterns are introduced.
+   - **Repository Hygiene Check**: Inspect changed files against `.specify/extensions/architecture-guard/hygiene-rules` (no `.tmp`, `.new`, or scratch files left behind; no commented-out code; no dead imports).
+   - **Heuristic SonarLint Scan**: Check changed files against `.specify/extensions/architecture-guard/sonar-rules/sonarlint-rules.json` (ensure no cognitive overload, tight coupling, loose `any`/`unknown` casts, or missing parameter validation).
    - **Immediate Remediation**: Correct any detected quality or hygiene violations immediately at the current task boundary.
 5. **Sync the tasks**: You MUST update `specs/<feature>/tasks.md` to mark completed tasks with `[x]`, check them off, and add any new subtasks discovered during implementation.
 6. The implementation MUST follow current tasks and context. Use Flash-Mem first when available. If retrieval is unavailable or insufficient, read active artifacts and constitution files directly with file-reading tools. Do not rely solely on workspace search or semantic indexes because these files are often in `.gitignore`.

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,15 @@
+## 2.3.8
+
+- Added Deprecated & Dangerous Code hygiene rule (`hygiene-rules/deprecated-and-dangerous-code.md`) with default Critical (blocking) severity, cataloging obsolete language and framework patterns (PHP, JS/TS, Node.js, Angular, React, Security).
+- Added pre-implementation and task preflight deprecation checks to `governed-implement` workflow.
+- Updated repository hygiene documentation and configuration options.
+
+## 2.3.7
+
+- Added Angular architecture preset (`presets/angular.md`) supporting modern Angular conventions (Signals, Standalone components, `inject()` DI, `OnPush` change detection, typed reactive forms, DTOs, and functional guards/interceptors).
+- Added deep interactive interview inquiry flow for Angular-specific concerns (Signals-to-RxJS interop, Hydration/SSR & `@defer`, Micro-frontends/Module Federation, and `@angular-eslint`).
+- Updated preset documentation, templates, and init command options.
+
 ## 2.3.6
 
 - Aligned SDD orchestration and legacy skills across adapters, commands, and workflows.

--- a/docs/repository-hygiene.md
+++ b/docs/repository-hygiene.md
@@ -58,6 +58,7 @@ The following hygiene categories are checked by default:
 - **TODO / FIXME**: Unresolved markers (configurable severity).
 - **Commented-Out Code**: Large blocks of disabled source code.
 - **Generated Artifacts**: Compiled outputs accidentally committed.
+- **Deprecated & Dangerous Code**: Deprecated, obsolete, or unsafe language and framework APIs (e.g. PHP deprecated syntax/functions, unmanaged Angular subscriptions, dangerous `eval`/`unserialize`, insecure hashing) that cause runtime failures or security risks. Defaults to **Critical** (blocking).
 
 ## Custom Rules
 

--- a/hygiene-rules/deprecated-and-dangerous-code.md
+++ b/hygiene-rules/deprecated-and-dangerous-code.md
@@ -1,0 +1,99 @@
+# Rule: Deprecated & Dangerous Code
+
+**Identifier**: `deprecated-and-dangerous-code`
+**Description**: Detect and forbid obsolete, deprecated, removed, or dangerous language and framework APIs that cause runtime errors, security vulnerabilities, or severe regressions.
+**Default Severity**: Critical
+**Recommendation**: Always replace deprecated or dangerous constructs with standard, actively supported language or framework capabilities prior to writing or committing code.
+
+## Purpose
+
+AI agents and developers frequently introduce deprecated SDK methods, obsolete language syntax, or dangerous functions when generating implementation code. This rule provides an authoritative pre-implementation reference and verification gate to eliminate obsolete code patterns before they cause runtime failures.
+
+---
+
+## Pattern Catalog by Language & Framework
+
+### 1. PHP (PHP 8.0 - 8.3+)
+
+| Deprecated / Dangerous Pattern | Failure Mode / Risk | Approved Modern Replacement |
+|---|---|---|
+| Dynamic Properties (setting undeclared class properties) | Deprecated in PHP 8.2; fatal in PHP 9.0 | Explicitly declare typed properties or use `#[AllowDynamicProperties]` attribute when justified |
+| `utf8_encode()`, `utf8_decode()` | Deprecated in PHP 8.2; removed in PHP 9.0 | `mb_convert_encoding()` or `intl` extension (`UConverter`) |
+| `create_function()` | Removed in PHP 8.0 (Fatal Error / RCE risk) | Native anonymous functions / closures (`function() {}` or `fn() => ...`) |
+| `each()` | Removed in PHP 8.0 | `foreach ($array as $key => $value)` or `ArrayIterator` |
+| `mysql_*` functions (`mysql_query`, `mysql_connect`) | Removed in PHP 7.0 | `PDO` with prepared statements or `mysqli` |
+| `unserialize()` on untrusted input | Arbitrary PHP object injection / RCE | `json_decode()` or safe typed DTO deserialization |
+| `eval()` with variable or user input | Remote Code Execution (RCE) | Structured data parsing, strategies, or expression language engines |
+
+---
+
+### 2. JavaScript / TypeScript / Node.js
+
+| Deprecated / Dangerous Pattern | Failure Mode / Risk | Approved Modern Replacement |
+|---|---|---|
+| `new Buffer(...)` | Deprecated and security vulnerability | `Buffer.from(...)` or `Buffer.alloc(...)` |
+| `String.prototype.substr()` | Deprecated in Web standards | `String.prototype.substring()` or `String.prototype.slice()` |
+| `fs.exists()` | Deprecated; causes race conditions (TOCTOU) | `fs.access()`, `fs.promises.access()`, or handle `ENOENT` on `fs.readFile()` / `fs.stat()` |
+| Synchronous blocking I/O (`fs.readFileSync`, `crypto.pbkdf2Sync`) inside web request handlers | Blocks Node.js event loop, crippling throughput | Asynchronous APIs (`fs.promises.*`, `async/await`) |
+| `document.write()` | Performance regression, security risks | DOM APIs (`element.appendChild()`, `textContent`) or framework data-binding |
+| Loose `eval()` / `new Function()` with dynamic strings | Cross-Site Scripting (XSS) / Code Injection | Standard parser, JSON parsing, or isolated sandbox |
+
+---
+
+### 3. Angular (Modern Angular 16 - 19+)
+
+| Deprecated / Dangerous Pattern | Failure Mode / Risk | Approved Modern Replacement |
+|---|---|---|
+| Unmanaged `.subscribe()` in components | Memory leak, stale event triggers | `AsyncPipe` (`observable$ \| async`), `toSignal()`, or `takeUntilDestroyed()` |
+| Direct DOM access (`document.getElementById()`, `element.innerHTML`) | Breaks Server-Side Rendering (SSR) & Hydration, XSS risk | Angular Template syntax, Signals, `Renderer2`, `ElementRef`, or `isPlatformBrowser()` guards |
+| Mutating `@Input()` or `input()` properties directly | One-way data-flow violation, unpredictable change detection | Readonly inputs, emit events via `output()`, or use two-way `model()` |
+| `ComponentFactoryResolver` | Deprecated in Angular 13+; removed in modern Angular | `ViewContainerRef.createComponent()` |
+| Legacy NgModule declarations for new features | Increased bundle size, complex boilerplate | Standalone Components (`standalone: true` or default in v17+) |
+
+---
+
+### 4. React (React 18 - 19+)
+
+| Deprecated / Dangerous Pattern | Failure Mode / Risk | Approved Modern Replacement |
+|---|---|---|
+| Legacy lifecycles (`componentWillMount`, `componentWillReceiveProps`, `componentWillUpdate`) | Removed or dangerous in Concurrent React | `useEffect()`, `useLayoutEffect()`, or custom hooks |
+| `defaultProps` on Function Components | Deprecated in React 18+; removed in React 19 | JavaScript default parameter values (`function Component({ prop = defaultVal })`) |
+| Direct state mutation (e.g. `this.state.x = y` or mutating state objects directly) | Breaks React re-renders and immutability guarantees | `useState()`, `useReducer()`, or immutable state updates (`setState({...prev, x: y})`) |
+| Unmemoized heavy calculations in render body | Severe frame drops and UI lag | `useMemo()` or derive state in event handlers / state stores |
+
+---
+
+### 5. Security & General Web Standards
+
+| Deprecated / Dangerous Pattern | Failure Mode / Risk | Approved Modern Replacement |
+|---|---|---|
+| Plain `md5()` or `sha1()` for passwords | Cryptographically broken; trivial collision/rainbow attacks | `bcrypt`, `argon2id`, or PBKDF2 with high iteration counts |
+| `Math.random()` for tokens, nonces, or security keys | Cryptographically insecure PRNG (predictable numbers) | `crypto.getRandomValues()` (Web API) or `crypto.randomBytes()` (Node.js) |
+| Hardcoded API secrets, JWT keys, or database credentials | Secret exposure in version control | Environment variables / Secret manager services |
+
+---
+
+## Detection & Enforcement
+
+1. **Pre-Implementation Preflight (`ag-governed-implement`)**:
+   - Before implementing any task, check the active language and framework against this catalog.
+   - If an obsolete pattern is considered in the technical design or task, substitute the approved replacement immediately.
+2. **Review & Verification Gates (`ag-verify`, `ag-review-implementation`)**:
+   - Flag any presence of listed deprecated or dangerous patterns as a **Critical** blocking violation.
+   - Do not pass verification until obsolete code is replaced with modern, supported constructs.
+
+---
+
+## Continuous Growth & Self-Learning Flow
+
+This catalog is designed to **grow dynamically during development**:
+
+1. **User Reported / Remediated Deprecations**:
+   - Whenever the user corrects an obsolete API or reports a deprecation/runtime error during implementation, Architecture Guard logs the entry into this file under the matching ecosystem section.
+2. **Post-Implementation & Archival Learning (`ag-governed-archive`, `ag-verify`)**:
+   - Newly discovered deprecated methods or refactored unsafe patterns are proposed for capture into:
+     - Local Hygiene Rule (`.architecture-guard/hygiene-rules/deprecated-and-dangerous-code.md`)
+     - Flash-Mem durable knowledge objects (`add_knowledge_object` / `add_memory` with tags `#deprecated-code`, `#anti-pattern`)
+3. **Project-Specific Custom Entries**:
+   - Teams can append internal legacy methods or deprecated service classes directly to this table to prevent AI agents from re-introducing them in future tasks.
+

--- a/orchestration/governed-implement.md
+++ b/orchestration/governed-implement.md
@@ -84,6 +84,7 @@ You must orchestrate the `{adapter_command:implement}` (core implementation) wor
    - Note in the Governance Summary that `{adapter_command:implement}` was unavailable and implementation was performed inline.
 3. **Write Code**: Perform the actual coding work (writing files, running tests) required by the tasks.
 4. **Inline Pre-Completion Self-Verification Gate**: Before marking any task complete:
+   - **Deprecated & Dangerous Code Check**: Check changed and target files against `{adapter_path:hygiene-rules}/deprecated-and-dangerous-code.md` (or local hygiene rules) to ensure no obsolete, deprecated, or fatal language/framework patterns are introduced.
    - **Repository Hygiene Check**: Inspect changed files against `{adapter_path:hygiene-rules}` (no `.tmp`, `.new`, or scratch files left behind; no commented-out code; no dead imports).
    - **Heuristic SonarLint Scan**: Check changed files against `{adapter_path:sonar-rules}/sonarlint-rules.json` (ensure no cognitive overload, tight coupling, loose `any`/`unknown` casts, or missing parameter validation).
    - **Immediate Remediation**: Correct any detected quality or hygiene violations immediately at the current task boundary.


### PR DESCRIPTION
## Summary

This pull request introduces the **Deprecated & Dangerous Code Hygiene Rule** (`hygiene-rules/deprecated-and-dangerous-code.md`) to Architecture Guard, establishing an authoritative catalog and preflight check to eliminate obsolete, deprecated, and dangerous code patterns before and during implementation.

### Key Changes

1. **Deprecated & Dangerous Code Rule (`hygiene-rules/deprecated-and-dangerous-code.md`)**:
   - **Default Severity**: `Critical` (Blocking).
   - **Organized Pattern Catalog**:
     - **PHP (8.0–8.3+)**: Dynamic properties deprecation, `utf8_encode`/`utf8_decode` removal, `create_function()`, `each()`, `mysql_*`, dangerous `unserialize()` on untrusted input, dynamic `eval()`.
     - **JavaScript / TypeScript / Node.js**: Deprecated `new Buffer()`, `String.prototype.substr()`, `fs.exists()`, synchronous blocking I/O in server event loops, `document.write()`, dynamic `eval()`.
     - **Angular (16–19+)**: Unmanaged `.subscribe()` in components, direct DOM access breaking SSR/Hydration, mutating `@Input()` / `input()`, `ComponentFactoryResolver`, legacy NgModules for new features.
     - **React (18–19+)**: Legacy lifecycles (`componentWillMount`, etc.), `defaultProps` on Function Components, direct state mutations.
     - **Security & Web Standards**: Plain MD5/SHA1 for passwords, `Math.random()` for security tokens/nonces, hardcoded credentials.
   - **Continuous Growth & Self-Learning Flow**: Explicitly supports logging user-reported deprecations and project-specific legacy methods so the rule grows dynamically and prevents recurring regressions.

2. **Pre-Implementation Preflight Integration**:
   - Updated `orchestration/governed-implement.md` and `commands/governed-implement.md` to require inspecting changed/target files against the deprecated code catalog prior to marking tasks complete.

3. **Documentation & Release Notes**:
   - Updated `docs/repository-hygiene.md` with rule details and configuration.
   - Updated `docs/release-notes.md` under version `2.3.8`.

### Verification
- Ran full test suite (`npm test`) — all 21 test suites passed.
- Architecture verification passed with 0 blocking and 0 advisory violations.
- Clean repository hygiene.