### PR TITLE
feat: bump version to 2.4.0 and streamline CLI init workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Keep AI-generated code aligned with your architecture, specs, and delivery workflow.
 
-[![Version](https://img.shields.io/badge/version-2.3.6-22c55e)](extension.yml)
+[![Version](https://img.shields.io/badge/version-2.4.0-22c55e)](extension.yml)
 [![OpenSpec](https://img.shields.io/badge/OpenSpec-compatible-8b5cf6)](https://github.com/Fission-AI/OpenSpec)
 [![Spec Kit](https://img.shields.io/badge/Spec%20Kit-compatible-2563eb)](https://spec-kit.dev)
 [![Non-blocking](https://img.shields.io/badge/style-non--blocking-10b981)](https://spec-kit.dev)

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -279,7 +279,6 @@ async function installCommand(agentType: any, commandName: any, cmdDir: any, opt
   if (fs.existsSync(dest)) {
     const action = overwrite === 'keep-both' ? 'keep both' : (overwrite === 'skip' ? 'skip' : 'replace');
     if (action !== 'replace' && action !== 'keep both') {
-      console.log(`  → ${commandName}: skipped`);
       return;
     }
     if (action === 'keep both') dest = availableCopy(dest, cfg, sk, cmdDir, agentType);
@@ -296,15 +295,11 @@ async function installCommand(agentType: any, commandName: any, cmdDir: any, opt
       installYaml(sk, content, cmdDir, dest);
     }
     
-    let wfMsg = '';
     if (workflowsDir) {
       const wfDest = path.join(workflowsDir, `agx-${sk}.md`);
       fs.mkdirSync(path.dirname(wfDest), { recursive: true });
       fs.writeFileSync(wfDest, content);
-      wfMsg = ' (+ workflow)';
     }
-    
-    console.log(`  ✓ ${commandName} → ${agentType}${wfMsg}`);
   } catch (err) {
     console.error(`  ✗ ${commandName}: ${err.message}`);
   }
@@ -330,13 +325,9 @@ ${selectedAgents.map(agent => `- \`${path.join(AGENT_CONFIGS[agent].dir, '*')}\`
     const current = fs.readFileSync(agentsPath, 'utf8');
     if (!current.includes('Architecture Guard')) {
       fs.appendFileSync(agentsPath, preamble);
-      console.log(`  ✓ Appended rules to AGENTS.md`);
-    } else {
-      console.log(`  → AGENTS.md already has Architecture Guard rules, skipped`);
     }
   } else {
     fs.writeFileSync(agentsPath, preamble.trimStart());
-    console.log(`  ✓ Created AGENTS.md with Architecture Guard rules`);
   }
 }
 
@@ -345,7 +336,6 @@ async function installRuntimeResources(runtimeDir, opts: any = {}) {
   const action = overwrite === 'skip' ? 'skip' : 'replace';
 
   if (action !== 'replace') {
-    console.log('  → Runtime resources: skipped');
     return;
   }
 
@@ -519,8 +509,6 @@ async function runInit(targetDir, opts) {
     process.exit(0);
   }
 
-  console.log(`\nInstalling ${selectedCommands.length} commands for ${selectedAgents.length} agent(s)...\n`);
-
   for (const agent of selectedAgents) {
     const isAgy = agent === 'antigravity';
     let cmdDir;
@@ -537,7 +525,6 @@ async function runInit(targetDir, opts) {
     for (const cmd of selectedCommands) {
       await installCommand(agent, cmd, cmdDir, opts, isAgy ? workflowsDir : null);
     }
-    console.log();
   }
 
   const runtimeDir = path.join(targetDir, '.architecture-guard');
@@ -553,7 +540,6 @@ async function runInit(targetDir, opts) {
       const dest = path.join(adaptersDir, f);
       if (!fs.existsSync(dest)) {
         fs.copyFileSync(src, dest);
-        console.log(`  ✓ Copied adapters/${f}`);
       }
     }
   }

--- a/cli/install.ts
+++ b/cli/install.ts
@@ -265,7 +265,6 @@ function availableCopy(dest, cfg, sk, cmdDir, agentType) {
 async function installCommand(agentType: any, commandName: any, cmdDir: any, opts: any = {}, workflowsDir: any = null) {
   const cfg = AGENT_CONFIGS[agentType];
   if (!cfg) return;
-  const yes = !!opts.yes;
   const overwrite = opts.overwrite;
 
   const promptPath = path.join(ROOT_DIR, 'orchestration', `${commandName}.md`);
@@ -278,14 +277,9 @@ async function installCommand(agentType: any, commandName: any, cmdDir: any, opt
   let dest = commandDestination(cfg, sk, cmdDir, agentType);
 
   if (fs.existsSync(dest)) {
-    // ponytail: --yes is for CI idempotency — repeated runs should replace, not accumulate
-    // `init.architecture-guard-2.md`, `-3.md`, ... Save-the-original behavior is opt-in via
-    // `--overwrite keep-both`; interactive users still get the 3-way prompt.
-    const action = yes || opts.batchPrompted
-      ? (overwrite === 'keep-both' ? 'keep both' : (overwrite === 'skip' ? 'skip' : 'replace'))
-      : (await ask(`  ${path.relative(process.cwd(), dest)} exists:`, ['skip', 'replace', 'keep both']) || 'skip');
+    const action = overwrite === 'keep-both' ? 'keep both' : (overwrite === 'skip' ? 'skip' : 'replace');
     if (action !== 'replace' && action !== 'keep both') {
-      console.log(`  → ${commandName}: skipped (action: ${action}, exists: ${fs.existsSync(dest)}, dest: ${dest}, batchPrompted: ${opts.batchPrompted})`);
+      console.log(`  → ${commandName}: skipped`);
       return;
     }
     if (action === 'keep both') dest = availableCopy(dest, cfg, sk, cmdDir, agentType);
@@ -346,11 +340,9 @@ ${selectedAgents.map(agent => `- \`${path.join(AGENT_CONFIGS[agent].dir, '*')}\`
   }
 }
 
-async function installRuntimeResources(runtimeDir, yes = false) {
-  const hasResources = fs.existsSync(runtimeDir);
-  const action = hasResources
-    ? (yes ? 'replace' : await ask('Runtime resources exist:', ['skip', 'replace']))
-    : 'replace';
+async function installRuntimeResources(runtimeDir, opts: any = {}) {
+  const overwrite = typeof opts === 'object' && opts !== null ? opts.overwrite : (opts ? 'replace' : null);
+  const action = overwrite === 'skip' ? 'skip' : 'replace';
 
   if (action !== 'replace') {
     console.log('  → Runtime resources: skipped');
@@ -419,11 +411,11 @@ Options:
   --agent <names>     Comma-separated agent keys (e.g. opencode,claude)
   --framework <f>     spec-kit | openspec | none
   --commands <list>   Comma-separated command names or indices (e.g. init,init-brownfield or 1,2)
-  --overwrite <mode>  With --yes: replace | skip | keep-both (default: replace for CI idempotency)
+  --overwrite <mode>  replace | skip | keep-both (default: replace)
 
 When --yes is set, --agent/--framework/--commands are honored; any missing value
-falls back to its first valid option. Without --overwrite, --yes replaces existing
-files; use --overwrite keep-both to preserve originals, or --overwrite skip to skip them.`);
+falls back to its first valid option. By default, existing files are replaced;
+use --overwrite keep-both to preserve originals, or --overwrite skip to skip them.`);
 }
 
 const REQUIRED_RESOURCES = ['templates', 'presets', 'hygiene-rules', 'sonar-rules'];
@@ -488,7 +480,18 @@ async function runInit(targetDir, opts) {
   const frameworks = ['spec-kit', 'openspec', 'none (framework-agnostic)'];
   let selectedFramework = opts.framework;
   if (!selectedFramework) {
-    selectedFramework = await ask('\nSelect SDD framework:', frameworks, false);
+    const hasOpenspec = fs.existsSync(path.join(targetDir, 'openspec', 'config.yaml')) || fs.existsSync(path.join(targetDir, 'openspec'));
+    const hasSpeckit = fs.existsSync(path.join(targetDir, '.specify'));
+
+    if (hasOpenspec && !hasSpeckit) {
+      selectedFramework = 'openspec';
+      console.log(`\nAuto-detected SDD framework: openspec`);
+    } else if (hasSpeckit && !hasOpenspec) {
+      selectedFramework = 'spec-kit';
+      console.log(`\nAuto-detected SDD framework: spec-kit`);
+    } else {
+      selectedFramework = await ask('\nSelect SDD framework:', frameworks, false);
+    }
   } else {
     const match = frameworks.find(f => f === selectedFramework || f.startsWith(selectedFramework));
     selectedFramework = match || (selectedFramework === 'none' ? 'none (framework-agnostic)' : selectedFramework);
@@ -508,31 +511,12 @@ async function runInit(targetDir, opts) {
       .map(s => /^\d+$/.test(s.trim()) ? COMMANDS[parseInt(s.trim(), 10) - 1] : s.trim())
       .filter(c => COMMANDS.includes(c));
   } else {
-    const choices = ['All', ...COMMANDS];
-    selectedCommands = await ask('\nSelect governance commands to install:', choices, true);
-    
-    if (selectedCommands && selectedCommands.includes('All')) {
-      selectedCommands = [...COMMANDS];
-    }
+    selectedCommands = [...COMMANDS];
   }
 
   if (!selectedCommands || selectedCommands.length === 0) {
     console.log('No commands selected. Exiting.');
     process.exit(0);
-  }
-
-  let agyScope = null;
-  const userPath = opts.target;
-  if (selectedAgents.includes('antigravity')) {
-    if (!userPath) {
-      const choices = ['Global (~/.gemini/antigravity-cli/skills)', 'Shared (~/.gemini/skills)', 'Workspace (current directory)'];
-      const scopeChoice = opts.yes ? choices[0] : (await ask('\nNo target path provided. Where would you like to install Antigravity skills?', choices, false) || '');
-      if (scopeChoice.startsWith('Global')) agyScope = 'global';
-      else if (scopeChoice.startsWith('Shared')) agyScope = 'shared';
-      else agyScope = 'workspace';
-    } else {
-      agyScope = 'workspace';
-    }
   }
 
   console.log(`\nInstalling ${selectedCommands.length} commands for ${selectedAgents.length} agent(s)...\n`);
@@ -543,50 +527,21 @@ async function runInit(targetDir, opts) {
     let workflowsDir = null;
     
     if (isAgy) {
-      if (agyScope === 'global') {
-        cmdDir = path.join(require('os').homedir(), '.gemini/antigravity-cli/skills');
-        workflowsDir = path.join(require('os').homedir(), '.gemini/antigravity-cli/workflows');
-      } else if (agyScope === 'shared') {
-        cmdDir = path.join(require('os').homedir(), '.gemini/skills');
-        workflowsDir = path.join(require('os').homedir(), '.gemini/workflows');
-      } else {
-        cmdDir = path.join(targetDir, '.agent/skills');
-        workflowsDir = path.join(targetDir, '.agent/workflows');
-      }
+      cmdDir = path.join(targetDir, '.agent/skills');
+      workflowsDir = path.join(targetDir, '.agent/workflows');
     } else {
       const cfg = AGENT_CONFIGS[agent];
       cmdDir = path.join(targetDir, cfg.dir);
     }
 
-    let batchOverwrite = opts.overwrite;
-    let batchPrompted = false;
-    if (!opts.yes && !batchOverwrite && selectedCommands.length > 1) {
-      let anyExists = false;
-      for (const cmd of selectedCommands) {
-        const sk = slug(cmd);
-        const cfg = AGENT_CONFIGS[agent];
-        const dest = isAgy ? path.join(cmdDir, `ag-${sk}`, 'SKILL.md') : commandDestination(cfg, sk, cmdDir, agent);
-        if (fs.existsSync(dest)) {
-          anyExists = true; break;
-        }
-      }
-      if (anyExists) {
-        const action = (await ask(`\nSome files already exist for ${agent}. What would you like to do for all of them?`, ['skip', 'replace', 'keep both'])) || 'skip';
-        batchOverwrite = action === 'keep both' ? 'keep-both' : action;
-        batchPrompted = true;
-      }
-    }
-
-    const currentOpts = { ...opts, overwrite: batchOverwrite || opts.overwrite, batchPrompted };
-
     for (const cmd of selectedCommands) {
-      await installCommand(agent, cmd, cmdDir, currentOpts, isAgy ? workflowsDir : null);
+      await installCommand(agent, cmd, cmdDir, opts, isAgy ? workflowsDir : null);
     }
     console.log();
   }
 
   const runtimeDir = path.join(targetDir, '.architecture-guard');
-  await installRuntimeResources(runtimeDir, opts.yes);
+  await installRuntimeResources(runtimeDir, opts);
 
   const adaptersDir = path.join(targetDir, 'adapters');
   const srcAdaptersDir = path.join(ROOT_DIR, 'adapters');
@@ -604,10 +559,7 @@ async function runInit(targetDir, opts) {
   }
   fs.writeFileSync(path.join(runtimeDir, 'selected-adapter'), `${framework === 'none' ? 'generic' : framework}\n`);
 
-  const updateAgents = opts.yes || (await ask('\nAppend governance rules to AGENTS.md? (y/n): ', null));
-  if (updateAgents && (opts.yes || ['y', 'yes'].includes(String(updateAgents).toLowerCase()))) {
-    appendAgentsMd(targetDir, selectedAgents);
-  }
+  appendAgentsMd(targetDir, selectedAgents);
 
   console.log('\nInstallation complete!');
   console.log(`Target: ${targetDir}`);

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -256,7 +256,7 @@ specify extension add architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.3.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
 ```
 
 ### Global Preset Usage
@@ -272,7 +272,7 @@ If you manage multiple projects using the same framework (e.g., Laravel), you ca
 
 ```bash
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.3.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
 ```
 
 ### From a Local Developer Artifact
@@ -285,5 +285,5 @@ specify extension add architecture-guard --dev /path/to/architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.3.3.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,14 +1,13 @@
-## 2.3.8
-
-- Added Deprecated & Dangerous Code hygiene rule (`hygiene-rules/deprecated-and-dangerous-code.md`) with default Critical (blocking) severity, cataloging obsolete language and framework patterns (PHP, JS/TS, Node.js, Angular, React, Security).
-- Added pre-implementation and task preflight deprecation checks to `governed-implement` workflow.
-- Updated repository hygiene documentation and configuration options.
-
-## 2.3.7
+## 2.4.0
 
 - Added Angular architecture preset (`presets/angular.md`) supporting modern Angular conventions (Signals, Standalone components, `inject()` DI, `OnPush` change detection, typed reactive forms, DTOs, and functional guards/interceptors).
 - Added deep interactive interview inquiry flow for Angular-specific concerns (Signals-to-RxJS interop, Hydration/SSR & `@defer`, Micro-frontends/Module Federation, and `@angular-eslint`).
-- Updated preset documentation, templates, and init command options.
+- Added Deprecated & Dangerous Code hygiene rule (`hygiene-rules/deprecated-and-dangerous-code.md`) with default Critical (blocking) severity, cataloging obsolete language and framework patterns (PHP, JS/TS, Node.js, Angular, React, Security).
+- Added pre-implementation and task preflight deprecation checks to `governed-implement` workflow.
+- Streamlined interactive CLI initialization: auto-detects single SDD frameworks, installs all commands by default, automatically replaces skills/resources, scopes Antigravity to workspace, and auto-updates `AGENTS.md` without prompt fatigue.
+- Updated preset documentation, repository hygiene documentation, templates, and init command options.
+
+
 
 ## 2.3.6
 

--- a/extension.yml
+++ b/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "architecture-guard"
   name: "Architecture Guard"
-  version: "2.3.6"
+  version: "2.4.0"
   description: "Framework-agnostic architecture review extension for validating implementation against governance and architecture constitutions, detecting architectural drift, and generating non-blocking refactor tasks."
   author: "DyanGalih"
   repository: "https://github.com/DyanGalih/architecture-guard"

--- a/install.test.ts
+++ b/install.test.ts
@@ -63,12 +63,12 @@ function install(input, cwd) {
 
 test('installs every agent format at the project root with selected resources only', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
-  install('all\n1\n1\nn\n', cwd);
+  install('all\n1\n', cwd);
 
   assert.equal(Object.keys(require('./cli/install').AGENT_CONFIGS).length, 35);
   assert.ok(fs.existsSync(path.join(cwd, '.opencode/commands/ag-init.md')));
   assert.ok(!fs.existsSync(path.join(cwd, cwd.slice(1), '.opencode/commands/ag-init.md')));
-   assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
+  assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
   assert.ok(fs.existsSync(path.join(cwd, 'adapters/spec-kit.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/openspec.md')));
   assert.equal(fs.readFileSync(path.join(cwd, '.architecture-guard/selected-adapter'), 'utf8').trim(), 'spec-kit');
@@ -77,21 +77,26 @@ test('installs every agent format at the project root with selected resources on
   }
 });
 
-test('existing commands skip by default, replace, or keep both', () => {
+test('existing commands auto-replace by default, and support --overwrite skip or keep-both', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
   const dest = path.join(cwd, '.opencode/commands/ag-init.md');
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.writeFileSync(dest, 'original');
 
-  install('1\n3\n2\n\nn\n', cwd);
-  assert.equal(fs.readFileSync(dest, 'utf8'), 'original');
-  install('1\n3\n2\n2\n\nn\n', cwd);
+  // Default interactive install without --overwrite automatically replaces existing files
+  install('1\n3\n', cwd);
   assert.notEqual(fs.readFileSync(dest, 'utf8'), 'original');
+
+  // With --overwrite skip, existing file is preserved
   fs.writeFileSync(dest, 'original');
-  install('1\n3\n2\n3\n\nn\n', cwd);
+  spawnSync(process.execPath, [installer, 'init', '--overwrite', 'skip'], { cwd, input: '1\n3\n', encoding: 'utf8' });
+  assert.equal(fs.readFileSync(dest, 'utf8'), 'original');
+
+  // With --overwrite keep-both, existing file is preserved and sibling is created
+  spawnSync(process.execPath, [installer, 'init', '--overwrite', 'keep-both'], { cwd, input: '1\n3\n', encoding: 'utf8' });
   assert.equal(fs.readFileSync(dest, 'utf8'), 'original');
   assert.ok(fs.existsSync(path.join(cwd, '.opencode/commands/ag-init.architecture-guard.md')));
-   assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
+  assert.ok(fs.existsSync(path.join(cwd, 'adapters/resolve.md')));
   assert.ok(fs.existsSync(path.join(cwd, 'adapters/generic.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/spec-kit.md')));
   assert.ok(!fs.existsSync(path.join(cwd, 'adapters/openspec.md')));
@@ -103,23 +108,47 @@ test('keep both creates a discoverable sibling skill', () => {
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.writeFileSync(dest, 'original');
 
-  install('1\n3\n2\n3\nn\n', cwd);
+  spawnSync(process.execPath, [installer, 'init', '--overwrite', 'keep-both'], { cwd, input: '1\n3\n', encoding: 'utf8' });
   assert.equal(fs.readFileSync(dest, 'utf8'), 'original');
   assert.ok(fs.existsSync(path.join(cwd, '.claude/skills/ag-init-2/SKILL.md')));
 });
 
 test('uses discoverable skill layouts and selected destinations in AGENTS.md', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
-  install('2,8,35,10\n1\n2\n3\nn\n', cwd);
+  install('2,8,35,10\n1\n', cwd);
   assert.ok(fs.existsSync(path.join(cwd, '.cursor/skills/ag-init/SKILL.md')));
   assert.ok(fs.existsSync(path.join(cwd, '.codex/skills/ag-init/SKILL.md')));
   assert.ok(fs.existsSync(path.join(cwd, '.agents/skills/zed/ag-init/SKILL.md')) || true); // skip exact index test
   assert.ok(fs.existsSync(path.join(cwd, '.agents/skills/ag-init/SKILL.md')) || true);
 
   const agentsPath = path.join(cwd, 'AGENTS.md');
-  require('./cli/install').appendAgentsMd(cwd, ['opencode']);
-  assert.match(fs.readFileSync(agentsPath, 'utf8'), /\.opencode\/commands/);
-  assert.doesNotMatch(fs.readFileSync(agentsPath, 'utf8'), /\.agent\/skills\/codex/);
+  assert.match(fs.readFileSync(agentsPath, 'utf8'), /\.cursor\/skills/);
+  assert.match(fs.readFileSync(agentsPath, 'utf8'), /\.codex\/skills/);
+
+  const isolatedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-isolated-'));
+  const isolatedAgentsPath = path.join(isolatedCwd, 'AGENTS.md');
+  require('./cli/install').appendAgentsMd(isolatedCwd, ['opencode']);
+  assert.match(fs.readFileSync(isolatedAgentsPath, 'utf8'), /\.opencode\/commands/);
+  assert.doesNotMatch(fs.readFileSync(isolatedAgentsPath, 'utf8'), /\.agent\/skills\/codex/);
+});
+
+test('framework auto-detects when single SDD tool marker exists', () => {
+  // Test openspec auto-detection
+  const cwdOpenspec = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-openspec-'));
+  fs.mkdirSync(path.join(cwdOpenspec, 'openspec'), { recursive: true });
+  fs.writeFileSync(path.join(cwdOpenspec, 'openspec', 'config.yaml'), 'schema: spec-driven\n');
+  // Only agent choice needed (1 prompt)
+  install('1\n', cwdOpenspec);
+  assert.equal(fs.readFileSync(path.join(cwdOpenspec, '.architecture-guard/selected-adapter'), 'utf8').trim(), 'openspec');
+  assert.ok(fs.existsSync(path.join(cwdOpenspec, 'adapters/openspec.md')));
+
+  // Test speckit auto-detection
+  const cwdSpeckit = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-speckit-'));
+  fs.mkdirSync(path.join(cwdSpeckit, '.specify'), { recursive: true });
+  // Only agent choice needed (1 prompt)
+  install('1\n', cwdSpeckit);
+  assert.equal(fs.readFileSync(path.join(cwdSpeckit, '.architecture-guard/selected-adapter'), 'utf8').trim(), 'spec-kit');
+  assert.ok(fs.existsSync(path.join(cwdSpeckit, 'adapters/spec-kit.md')));
 });
 
 test('rejects missing runtime resources with actionable error', () => {
@@ -163,15 +192,18 @@ test('escapes TOML triple quotes and emits safe YAML metadata', () => {
   assert.match(fs.readFileSync(yaml, 'utf8'), /title: "ag-init"/);
 });
 
-test('runtime resources default to skip and replace on approval', () => {
+test('runtime resources auto-replace by default and can be skipped with --overwrite skip', () => {
   const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'architecture-guard-'));
-  install('1\n3\n2\nn\n', cwd);
+  install('1\n3\n', cwd);
   const template = path.join(cwd, '.architecture-guard/templates/ponytail_core.md');
   fs.writeFileSync(template, 'custom');
 
-  install('1\n3\n2\n\nn\n', cwd);
+  // With --overwrite skip, custom template is preserved
+  spawnSync(process.execPath, [installer, 'init', '--overwrite', 'skip'], { cwd, input: '1\n3\n', encoding: 'utf8' });
   assert.equal(fs.readFileSync(template, 'utf8'), 'custom');
-  install('1\n3\n2\n2\n2\nn\n', cwd);
+
+  // Default replaces custom template with latest
+  install('1\n3\n', cwd);
   assert.notEqual(fs.readFileSync(template, 'utf8'), 'custom');
 });
 

--- a/install.test.ts
+++ b/install.test.ts
@@ -274,7 +274,7 @@ test('--help prints usage and exits without writing files', () => {
 
 test('installer exposes init only and publishes linked documentation', () => {
   const pkg = require('../package.json');
-  assert.equal(require('./cli/self-update').compareSemver('2.3.0', '2.2.2'), 1);
+  assert.equal(require('./cli/self-update').compareSemver('2.4.0', '2.2.2'), 1);
   assert.equal(require('./cli/self-update').compareSemver('2.2.2', '2.2.2'), 0);
   assert.equal(require('./cli/self-update').compareSemver('2.2.1', '2.2.2'), -1);
   assert.equal(require('./cli/self-update').compareSemver('v2.2.2', '2.2.2'), 0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-guard",
-  "version": "2.3.6",
+  "version": "2.4.0",
   "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Resolves the selected SDD adapter and applies its mappings automatically.",
   "bin": {
     "architecture-guard": "./dist/bin/cli.js"


### PR DESCRIPTION
## Summary

- Bumped version to `2.4.0` and merged release notes.
- Streamlined interactive `architecture-guard init` CLI flow:
  - Auto-detects single SDD framework (`openspec` vs `spec-kit`) from workspace markers, bypassing the framework prompt unless ambiguous.
  - Defaults to installing all governance commands without presenting a command checklist.
  - Automatically replaces existing skills and runtime resources by default while preserving explicit `--overwrite skip` and `--overwrite keep-both` flags.
  - Scopes Antigravity skills directly to the local workspace (`.agent/skills` and `.agent/workflows`).
  - Auto-updates `AGENTS.md` without interactive prompt.
- Added comprehensive unit tests in `install.test.ts`.