### PR TITLE
feat(openspec): enforce schema-compliant rules and bump to v2.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > Keep AI-generated code aligned with your architecture, specs, and delivery workflow.
 
-[![Version](https://img.shields.io/badge/version-2.4.0-22c55e)](extension.yml)
+[![Version](https://img.shields.io/badge/version-2.4.1-22c55e)](extension.yml)
 [![OpenSpec](https://img.shields.io/badge/OpenSpec-compatible-8b5cf6)](https://github.com/Fission-AI/OpenSpec)
 [![Spec Kit](https://img.shields.io/badge/Spec%20Kit-compatible-2563eb)](https://spec-kit.dev)
 [![Non-blocking](https://img.shields.io/badge/style-non--blocking-10b981)](https://spec-kit.dev)

--- a/adapters/openspec.md
+++ b/adapters/openspec.md
@@ -79,10 +79,15 @@ context: |
   ## Testing Standards
   - [Per project]
 
-# Per-artifact rules
+# Per-artifact rules (MUST only use schema artifact IDs: proposal, specs, design, tasks)
+# Verification requirements and quality standards belong in context: (e.g. ## Testing Standards), not under rules.
 rules:
   proposal:
     - Keep proposals under 500 words
+  specs:
+    - Include measurable acceptance criteria
+  design:
+    - Document data structures and boundary contracts
   tasks:
     - Break tasks into chunks of max 2 hours
 ```

--- a/docs/reference-manual.md
+++ b/docs/reference-manual.md
@@ -256,7 +256,7 @@ specify extension add architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.1.zip
 ```
 
 ### Global Preset Usage
@@ -272,7 +272,7 @@ If you manage multiple projects using the same framework (e.g., Laravel), you ca
 
 ```bash
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.1.zip
 ```
 
 ### From a Local Developer Artifact
@@ -285,5 +285,5 @@ specify extension add architecture-guard --dev /path/to/architecture-guard
 
 ```text
 specify extension add architecture-guard --from \
-  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.0.zip
+  https://github.com/DyanGalih/architecture-guard/archive/refs/tags/v2.4.1.zip
 ```

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,9 @@
+## 2.4.1
+
+- Enforce schema-compliant OpenSpec artifact keys in `rules:` (`proposal`, `specs`, `design`, `tasks`).
+- Relocate verification-only requirements and testing standards into top-level shared `context:` block in `openspec/config.yaml` and `ag-init` templates.
+- Update `ag-init` guidance and OpenSpec adapter documentation to prevent schema validation warnings across agents.
+
 ## 2.4.0
 
 - Added Angular architecture preset (`presets/angular.md`) supporting modern Angular conventions (Signals, Standalone components, `inject()` DI, `OnPush` change detection, typed reactive forms, DTOs, and functional guards/interceptors).

--- a/extension.yml
+++ b/extension.yml
@@ -3,7 +3,7 @@ schema_version: "1.0"
 extension:
   id: "architecture-guard"
   name: "Architecture Guard"
-  version: "2.4.0"
+  version: "2.4.1"
   description: "Framework-agnostic architecture review extension for validating implementation against governance and architecture constitutions, detecting architectural drift, and generating non-blocking refactor tasks."
   author: "DyanGalih"
   repository: "https://github.com/DyanGalih/architecture-guard"

--- a/orchestration/init.md
+++ b/orchestration/init.md
@@ -762,7 +762,8 @@ Examples:
 Ask:
 
 ```text
-If the active adapter supports per-artifact rules (for example, OpenSpec rules), do you want lightweight checklists for specs and design?
+If the active adapter supports per-artifact rules (for example, OpenSpec rules), do you want lightweight checklists for proposal, specs, design, or tasks?
+(Note: OpenSpec rules must strictly map to schema artifact IDs: proposal, specs, design, tasks. Verification/testing rules belong in the shared context block.)
 (Skip if the active adapter lacks a per-artifact rule mechanism)
 ```
 
@@ -1039,7 +1040,7 @@ The generated constitutions must reflect intentional engineering decisions.
 The init interview produces framework-specific constitution files:
 
 - **SpecKit adapter**: Writes `{adapter_path:constitution}`, `{adapter_path:arch-constitution}`, `{adapter_path:security-constitution}`
-- **OpenSpec adapter**: Updates `{adapter_path:constitution}` (config context and rules); `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` remain optional splits and, when present, are reconciled with config so each rule has one canonical owner
+- **OpenSpec adapter**: Updates `{adapter_path:constitution}` (config context and rules). The `rules:` mapping MUST strictly use schema artifact IDs (`proposal`, `specs`, `design`, `tasks`). Verification-only and testing requirements belong in the shared `context:` block (e.g. under `## Testing Standards`) rather than under `rules.verify`. `{adapter_path:arch-constitution}` and `{adapter_path:security-constitution}` remain optional splits and, when present, are reconciled with config so each rule has one canonical owner
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "architecture-guard",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "SDD-tool-agnostic architecture governance orchestrator for Spec Kit, OpenSpec, and generic Markdown workflows. Resolves the selected SDD adapter and applies its mappings automatically.",
   "bin": {
     "architecture-guard": "./dist/bin/cli.js"


### PR DESCRIPTION
## Summary
- Enforce schema-compliant OpenSpec artifact keys in `rules:` (`proposal`, `specs`, `design`, `tasks`).
- Move verification-only requirements and testing standards into top-level shared `context:` block in `openspec/config.yaml` and `ag-init` templates.
- Update `ag-init` guidance and OpenSpec adapter documentation to prevent schema validation warnings.
- Bump package version to `2.4.1` and synchronize version across all documentation and manifests.